### PR TITLE
fix: remove nginx from accounting compose

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -121,34 +121,9 @@ services:
     networks:
       - accounting-network
 
-  nginx:
-    image: nginx:alpine
-    container_name: accounting-nginx
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf:ro
-      - /etc/letsencrypt:/etc/letsencrypt:ro
-      - /opt/certbot-webroot:/var/www/certbot:ro
-    depends_on:
-      - web
-      - api
-    restart: unless-stopped
-    deploy:
-      resources:
-        limits:
-          memory: 128M
-    networks:
-      - accounting-network
-      - marketing-network
-
 volumes:
   postgres_data_prod:
 
 networks:
   accounting-network:
     driver: bridge
-  marketing-network:
-    external: true
-    name: marketing-ai_marketing-network


### PR DESCRIPTION
## Summary
- Nginx reverse proxy moved to shared `/opt/shared-nginx/` on the server
- Each project (accounting, ai-budget, marketing) has its own config file in `conf.d/`
- Removes nginx service and marketing-network from accounting compose to prevent port 80/443 conflicts during deploy

## Context
The accounting nginx container was the single point of entry for all 3 projects. When accounting redeployed, it tried to bind ports 80/443 which were already taken by `shared-nginx`, causing deploy failures.

## Test plan
- [x] Verified all 3 domains work after the change (eksiegowyai.pl, emarketingai.pl, admin.ai-budget.pl)
- [ ] Merge and trigger accounting deploy — should succeed without port conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)