### PR TITLE
chore(api): Sentry init log format fix + verify-sentry script

### DIFF
--- a/packages/api/scripts/verify-sentry.ts
+++ b/packages/api/scripts/verify-sentry.ts
@@ -1,0 +1,45 @@
+/**
+ * One-off Sentry verification script. NOT committed.
+ *
+ * Run with:
+ *   cd packages/api && npx tsx scripts/verify-sentry.ts
+ *
+ * Sends a captureMessage + captureException to Sentry, flushes, and exits.
+ * Then check https://sentry.io for new issues in the project.
+ */
+
+import 'dotenv/config';
+import { initSentry, Sentry } from '../src/lib/sentry';
+
+async function main() {
+  console.log('[verify-sentry] DSN configured:', !!process.env.SENTRY_DSN);
+  console.log('[verify-sentry] Environment:', process.env.NODE_ENV ?? 'unset');
+
+  initSentry();
+
+  if (!process.env.SENTRY_DSN) {
+    console.error('[verify-sentry] SENTRY_DSN not set. Aborting.');
+    process.exit(1);
+  }
+
+  const stamp = new Date().toISOString();
+  const messageId = Sentry.captureMessage(`[verify-sentry] Test message at ${stamp}`, 'info');
+  const exceptionId = Sentry.captureException(
+    new Error(`[verify-sentry] Test exception at ${stamp}`),
+  );
+
+  console.log('[verify-sentry] captureMessage event id:', messageId);
+  console.log('[verify-sentry] captureException event id:', exceptionId);
+  console.log('[verify-sentry] Flushing...');
+
+  const flushed = await Sentry.flush(5000);
+  console.log('[verify-sentry] Flush result:', flushed);
+
+  await Sentry.close(2000);
+  console.log('[verify-sentry] Done. Check https://sentry.io/ for the two events.');
+}
+
+main().catch((err) => {
+  console.error('[verify-sentry] Failed:', err);
+  process.exit(1);
+});

--- a/packages/api/src/lib/sentry.ts
+++ b/packages/api/src/lib/sentry.ts
@@ -28,7 +28,7 @@ export function initSentry(): void {
     },
   });
 
-  logger.info('[Sentry] Initialized for environment:', process.env.NODE_ENV);
+  logger.info(`[Sentry] Initialized for environment: ${process.env.NODE_ENV}`);
 }
 
 export { Sentry };


### PR DESCRIPTION
Post-merge follow-up to #105.

## Changes

- **lib/sentry.ts**: use template literal in the init log so Winston doesn't splat the env string character-by-character into metadata (cosmetic, but makes logs readable)
- **scripts/verify-sentry.ts**: standalone tool that loads Sentry config and sends one captureMessage + one captureException so an operator can confirm DSN routing on a fresh deployment. Run with `npx tsx scripts/verify-sentry.ts`

Verified locally — both events delivered to Sentry, flush returned `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)