### PR TITLE
fix(web): guide language dropdown, smaller header logos, banner i18n fix

### DIFF
--- a/packages/web/src/components/chat/ChatHeader.tsx
+++ b/packages/web/src/components/chat/ChatHeader.tsx
@@ -124,8 +124,8 @@ export function ChatHeader({
               <img
                 src="/logo.svg"
                 alt="eKsięgowy AI"
-                width={96}
-                height={96}
+                width={56}
+                height={56}
               />
             </Link>
             <div>

--- a/packages/web/src/components/guide/GuidePageLayout.tsx
+++ b/packages/web/src/components/guide/GuidePageLayout.tsx
@@ -12,9 +12,14 @@ interface Props {
   children: React.ReactNode;
 }
 
+const LOCALE_OPTIONS: { value: Locale; label: string }[] = [
+  { value: 'en', label: 'EN' },
+  { value: 'pl', label: 'PL' },
+  { value: 'ru', label: 'RU' },
+];
+
 export function GuidePageLayout({ title, summary, breadcrumbs, children }: Props) {
   const { locale, setLocale } = useLocale();
-  const locales: Locale[] = ['en', 'pl', 'ru'];
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
@@ -30,21 +35,16 @@ export function GuidePageLayout({ title, summary, breadcrumbs, children }: Props
             </Link>
             <span className="font-semibold text-gray-900 dark:text-white text-sm">eKsięgowy AI</span>
           </div>
-          <div className="flex items-center gap-1">
-            {locales.map((l) => (
-              <button
-                key={l}
-                onClick={() => setLocale(l)}
-                className={`px-2 py-1 text-xs rounded uppercase font-medium transition-colors ${
-                  locale === l
-                    ? 'bg-blue-600 text-white'
-                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-700'
-                }`}
-              >
-                {l}
-              </button>
+          <select
+            value={locale}
+            onChange={(e) => setLocale(e.target.value as Locale)}
+            className="px-2 py-1 text-xs font-medium rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-transparent cursor-pointer"
+            aria-label="Language"
+          >
+            {LOCALE_OPTIONS.map((l) => (
+              <option key={l.value} value={l.value}>{l.label}</option>
             ))}
-          </div>
+          </select>
         </div>
       </header>
 

--- a/packages/web/src/components/landing/LandingHeader.tsx
+++ b/packages/web/src/components/landing/LandingHeader.tsx
@@ -25,7 +25,7 @@ export function LandingHeader() {
 
   return (
     <header className="sticky top-0 z-50 bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm border-b border-gray-200 dark:border-gray-700">
-      <div className="max-w-6xl mx-auto px-4 h-32 flex items-center justify-between">
+      <div className="max-w-6xl mx-auto px-4 h-20 flex items-center justify-between">
         {/* Logo */}
         <Link
           href="/"
@@ -35,8 +35,8 @@ export function LandingHeader() {
           <img
             src="/logo.svg"
             alt="eKsięgowy AI"
-            width={112}
-            height={112}
+            width={64}
+            height={64}
           />
           <span className="text-xl font-bold text-gray-900 dark:text-white">
             eKsiegowy AI

--- a/packages/web/src/components/system/SystemStatusBanner.tsx
+++ b/packages/web/src/components/system/SystemStatusBanner.tsx
@@ -1,27 +1,42 @@
 'use client';
 
-import { useTranslations } from 'next-intl';
+import { useLocale } from '@/contexts/LocaleContext';
 import { useSystemHealth } from '@/hooks/useSystemHealth';
 import type { HealthSnapshot } from '@/lib/api/health';
+import en from '@/i18n/locales/en.json';
+import pl from '@/i18n/locales/pl.json';
+import ru from '@/i18n/locales/ru.json';
+
+const translations = { en, pl, ru };
+
+type BannerKey = 'unreachable' | 'down' | 'degraded.ai' | 'degraded.wfirma';
 
 function buildKey(
   status: 'unreachable' | 'down' | 'degraded',
   snapshot: HealthSnapshot | undefined,
-): string | null {
-  if (status === 'unreachable') return 'banner.unreachable';
-  if (status === 'down') return 'banner.down';
+): BannerKey | null {
+  if (status === 'unreachable') return 'unreachable';
+  if (status === 'down') return 'down';
   if (status === 'degraded') {
     const i = snapshot?.integrations;
-    if (i && (!i.openai.ok || !i.anthropic.ok)) return 'banner.degraded.ai';
-    if (i && !i.wfirma.ok) return 'banner.degraded.wfirma';
-    return 'banner.down'; // fallback if degraded but reason unknown
+    if (i && (!i.openai.ok || !i.anthropic.ok)) return 'degraded.ai';
+    if (i && !i.wfirma.ok) return 'degraded.wfirma';
+    return 'down';
   }
   return null;
 }
 
+function getMessage(locale: 'en' | 'pl' | 'ru', key: BannerKey): string {
+  const banner = translations[locale].system.banner;
+  if (key === 'unreachable') return banner.unreachable;
+  if (key === 'down') return banner.down;
+  if (key === 'degraded.ai') return banner.degraded.ai;
+  return banner.degraded.wfirma;
+}
+
 export function SystemStatusBanner() {
   const { status, snapshot } = useSystemHealth();
-  const t = useTranslations('system');
+  const { locale } = useLocale();
 
   if (status === 'ok') return null;
 
@@ -38,7 +53,7 @@ export function SystemStatusBanner() {
 
   return (
     <div role="status" aria-live="polite" className={className}>
-      {t(key)}
+      {getMessage(locale, key)}
     </div>
   );
 }

--- a/packages/web/src/components/system/__tests__/SystemStatusBanner.test.tsx
+++ b/packages/web/src/components/system/__tests__/SystemStatusBanner.test.tsx
@@ -1,14 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import { SystemStatusBanner } from '../SystemStatusBanner';
+import en from '@/i18n/locales/en.json';
 
 const mockSystemHealth = jest.fn();
 jest.mock('@/hooks/useSystemHealth', () => ({
   useSystemHealth: () => mockSystemHealth(),
 }));
 
-jest.mock('next-intl', () => ({
-  useTranslations: () => (key: string) => key, // returns key, easy to assert
+jest.mock('@/contexts/LocaleContext', () => ({
+  useLocale: () => ({ locale: 'en', setLocale: jest.fn() }),
 }));
+
+const banner = en.system.banner;
 
 describe('SystemStatusBanner', () => {
   it('renders nothing when status is ok', () => {
@@ -20,13 +23,13 @@ describe('SystemStatusBanner', () => {
   it('renders unreachable copy when offline', () => {
     mockSystemHealth.mockReturnValue({ status: 'unreachable' });
     render(<SystemStatusBanner />);
-    expect(screen.getByText(/banner.unreachable/)).toBeInTheDocument();
+    expect(screen.getByText(banner.unreachable)).toBeInTheDocument();
   });
 
   it('renders down copy when status=down', () => {
     mockSystemHealth.mockReturnValue({ status: 'down' });
     render(<SystemStatusBanner />);
-    expect(screen.getByText(/banner.down/)).toBeInTheDocument();
+    expect(screen.getByText(banner.down)).toBeInTheDocument();
   });
 
   it('prioritizes AI degradation over wFirma when both fail', () => {
@@ -37,8 +40,8 @@ describe('SystemStatusBanner', () => {
       },
     });
     render(<SystemStatusBanner />);
-    expect(screen.getByText(/banner.degraded.ai/)).toBeInTheDocument();
-    expect(screen.queryByText(/banner.degraded.wfirma/)).not.toBeInTheDocument();
+    expect(screen.getByText(banner.degraded.ai)).toBeInTheDocument();
+    expect(screen.queryByText(banner.degraded.wfirma)).not.toBeInTheDocument();
   });
 
   it('shows wFirma copy when only wFirma is down', () => {
@@ -49,7 +52,7 @@ describe('SystemStatusBanner', () => {
       },
     });
     render(<SystemStatusBanner />);
-    expect(screen.getByText(/banner.degraded.wfirma/)).toBeInTheDocument();
+    expect(screen.getByText(banner.degraded.wfirma)).toBeInTheDocument();
   });
 
   it('uses role=status and aria-live=polite', () => {


### PR DESCRIPTION
## Summary
- **Guide pages**: replace EN/PL/RU button strip in `GuidePageLayout` with a `<select>` dropdown to match the locale switcher used in `LandingHeader`/elsewhere.
- **Headers too tall**: revert recent logo enlargements that pushed the header height up.
  - `LandingHeader`: `h-32` → `h-20`, logo `112×112` → `64×64`.
  - `ChatHeader`: logo `96×96` → `56×56`.
- **`SystemStatusBanner` i18n fix**: replace `useTranslations` from `next-intl` with the project's `LocaleContext` + JSON locale files. The component crashed at runtime with "Failed to call `useTranslations` because the context from `NextIntlClientProvider` was not found" because the project doesn't wrap the tree with `NextIntlClientProvider`. Test mock updated accordingly.

## Test plan
- [ ] `/guide` shows the dropdown locale switcher (matches `LandingHeader`).
- [ ] Landing page header is no longer overly tall.
- [ ] Chat header logo is back to a normal size.
- [ ] `/chat` no longer throws the `NextIntlClientProvider` runtime error.
- [ ] `npx jest src/components/system` passes (6/6 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)