### PR TITLE
AIA-93 Contractor autofill from Biała Lista MF when only NIP is given

### DIFF
--- a/packages/api/src/i18n/index.ts
+++ b/packages/api/src/i18n/index.ts
@@ -42,6 +42,8 @@ export interface ContractorTranslations {
   similarContractors: string;
   specifyNameUpdate: string;
   specifyNameDelete: string;
+  // Auto-fill from public registry
+  autoFilledFromRegistry: string;
 }
 
 export interface InvoiceTranslations {

--- a/packages/api/src/i18n/locales/en.json
+++ b/packages/api/src/i18n/locales/en.json
@@ -41,7 +41,8 @@
     "exactNotFound": "Contractor with exact name not found",
     "similarContractors": "Similar contractors",
     "specifyNameUpdate": "Please specify exact name for update.",
-    "specifyNameDelete": "Please specify exact name for deletion."
+    "specifyNameDelete": "Please specify exact name for deletion.",
+    "autoFilledFromRegistry": "Auto-filled from the Polish public registry (Biała Lista MF)"
   },
   "invoice": {
     "invoices": "Invoices",

--- a/packages/api/src/i18n/locales/pl.json
+++ b/packages/api/src/i18n/locales/pl.json
@@ -41,7 +41,8 @@
     "exactNotFound": "Nie znaleziono kontrahenta o dokładnej nazwie",
     "similarContractors": "Podobni kontrahenci",
     "specifyNameUpdate": "Podaj dokładną nazwę do aktualizacji.",
-    "specifyNameDelete": "Podaj dokładną nazwę do usunięcia."
+    "specifyNameDelete": "Podaj dokładną nazwę do usunięcia.",
+    "autoFilledFromRegistry": "Uzupełnione automatycznie z rejestrów publicznych (Biała Lista MF)"
   },
   "invoice": {
     "invoices": "Faktury",

--- a/packages/api/src/i18n/locales/ru.json
+++ b/packages/api/src/i18n/locales/ru.json
@@ -41,7 +41,8 @@
     "exactNotFound": "Контрагент с точным названием не найден",
     "similarContractors": "Похожие контрагенты",
     "specifyNameUpdate": "Уточните название для обновления.",
-    "specifyNameDelete": "Уточните название для удаления."
+    "specifyNameDelete": "Уточните название для удаления.",
+    "autoFilledFromRegistry": "Автозаполнено из польского публичного реестра (Biała Lista МФ)"
   },
   "invoice": {
     "invoices": "Счета-фактуры",

--- a/packages/api/src/services/__tests__/company-enrichment.service.test.ts
+++ b/packages/api/src/services/__tests__/company-enrichment.service.test.ts
@@ -1,4 +1,8 @@
-import { CompanyEnrichmentService, validateNip } from '../company-enrichment.service';
+import {
+  CompanyEnrichmentService,
+  validateNip,
+  parsePolishAddress,
+} from '../company-enrichment.service';
 import axios from 'axios';
 
 // Mock axios
@@ -75,10 +79,12 @@ describe('CompanyEnrichmentService', () => {
             data: {
               result: {
                 subject: {
+                  name: 'MICODE SP. Z O.O.',
                   regon: '523456789',
                   krs: '0001234567',
                   statusVat: 'Czynny',
                   accountNumbers: ['PL12345678901234567890123456'],
+                  workingAddress: 'UL. PIĘKNA 47B/8, 00-672 WARSZAWA',
                 },
               },
             },
@@ -107,13 +113,41 @@ describe('CompanyEnrichmentService', () => {
       const result = await service.enrichByNip('5833510147', 'user-123');
 
       expect(result).toBeDefined();
+      expect(result!.name).toBe('MICODE SP. Z O.O.');
       expect(result!.regon).toBe('523456789');
       expect(result!.krs).toBe('0001234567');
       expect(result!.vatStatus).toBe('czynny');
       expect(result!.verifiedBankAccounts).toEqual(['PL12345678901234567890123456']);
+      expect(result!.workingAddress).toBe('UL. PIĘKNA 47B/8, 00-672 WARSZAWA');
       expect(result!.krsData?.legalForm).toBe('SPÓŁKA Z OGRANICZONĄ ODPOWIEDZIALNOŚCIĄ');
       expect(result!.krsData?.shareCapital).toBe('5000.00 PLN');
       expect(mockCacheService.cacheData).toHaveBeenCalled();
+    });
+
+    it('extracts residenceAddress for sole proprietors (no working address)', async () => {
+      mockCacheService.getCachedData.mockResolvedValue(null);
+      mockCacheService.cacheData.mockResolvedValue(undefined);
+      mockedAxios.get.mockImplementation((url: string) => {
+        if (url.includes('wl-api.mf.gov.pl')) {
+          return Promise.resolve({
+            data: {
+              result: {
+                subject: {
+                  name: 'JAN KOWALSKI - INDYWIDUALNA DZIAŁALNOŚĆ',
+                  statusVat: 'Czynny',
+                  residenceAddress: 'UL. KWIATOWA 5, 30-010 KRAKÓW',
+                },
+              },
+            },
+          });
+        }
+        return Promise.reject(new Error('KRS unavailable'));
+      });
+
+      const result = await service.enrichByNip('5833510147', 'user-123');
+      expect(result!.name).toBe('JAN KOWALSKI - INDYWIDUALNA DZIAŁALNOŚĆ');
+      expect(result!.residenceAddress).toBe('UL. KWIATOWA 5, 30-010 KRAKÓW');
+      expect(result!.workingAddress).toBeUndefined();
     });
 
     it('should return partial data when KRS fails', async () => {
@@ -159,5 +193,47 @@ describe('CompanyEnrichmentService', () => {
 
       expect(result).toBeNull();
     });
+  });
+});
+
+describe('parsePolishAddress', () => {
+  it('parses "STREET NN, ZIP CITY" format', () => {
+    expect(parsePolishAddress('UL. PIĘKNA 47B/8, 00-672 WARSZAWA')).toEqual({
+      street: 'UL. PIĘKNA 47B/8',
+      city: 'WARSZAWA',
+      zip: '00-672',
+    });
+  });
+
+  it('parses without leading "UL." prefix', () => {
+    expect(parsePolishAddress('PIĘKNA 47B/8, 00-672 WARSZAWA')).toEqual({
+      street: 'PIĘKNA 47B/8',
+      city: 'WARSZAWA',
+      zip: '00-672',
+    });
+  });
+
+  it('parses without comma separator', () => {
+    expect(parsePolishAddress('PIĘKNA 47B/8 00-672 WARSZAWA')).toEqual({
+      street: 'PIĘKNA 47B/8',
+      city: 'WARSZAWA',
+      zip: '00-672',
+    });
+  });
+
+  it('parses reversed order ("ZIP CITY, STREET")', () => {
+    expect(parsePolishAddress('00-672 WARSZAWA, UL. PIĘKNA 47B/8')).toEqual({
+      street: 'UL. PIĘKNA 47B/8',
+      city: 'WARSZAWA',
+      zip: '00-672',
+    });
+  });
+
+  it('returns street-only for input without postcode', () => {
+    expect(parsePolishAddress('SOMEWHERE')).toEqual({ street: 'SOMEWHERE' });
+  });
+
+  it('returns empty object for empty input', () => {
+    expect(parsePolishAddress('')).toEqual({});
   });
 });

--- a/packages/api/src/services/ai-chat/formatters/contractor.formatter.ts
+++ b/packages/api/src/services/ai-chat/formatters/contractor.formatter.ts
@@ -50,12 +50,19 @@ export function formatContractorDetails(contractor: WFirmaContractor, locale: Lo
 | **${t.notes}** | ${contractor.notes ? sanitizeForPrompt(contractor.notes) : '-'} |`;
 }
 
-export function formatContractorCreated(contractor: WFirmaContractor, locale: Locale = 'pl'): string {
+export function formatContractorCreated(
+  contractor: WFirmaContractor,
+  locale: Locale = 'pl',
+  autoFilledFields: string[] = [],
+): string {
   const t = getContractorTranslations(locale);
+  const autofillNote = autoFilledFields.length > 0
+    ? `\n> ✨ ${t.autoFilledFromRegistry}: ${autoFilledFields.join(', ')}\n`
+    : '';
   return `## ✅ ${t.created}
 
 ${formatContractorDetails(contractor, locale)}
-
+${autofillNote}
 > ${t.createdHint}`;
 }
 

--- a/packages/api/src/services/ai-chat/tools/contractor.tools.ts
+++ b/packages/api/src/services/ai-chat/tools/contractor.tools.ts
@@ -10,6 +10,11 @@ import { getContractorTranslations, Locale } from '../../../i18n';
 import { WFirmaIntegrationService } from '../../wfirma';
 import { WFirmaCacheService } from '../../wfirma-cache.service';
 import {
+  CompanyEnrichmentService,
+  parsePolishAddress,
+  validateNip,
+} from '../../company-enrichment.service';
+import {
   formatContractorsList,
   formatContractorCreated,
   formatContractorUpdated,
@@ -65,7 +70,8 @@ export function createCreateContractorTool(
   cacheService: WFirmaCacheService,
   userId: string,
   locale: Locale,
-  subscriptionService?: SubscriptionService
+  subscriptionService?: SubscriptionService,
+  enrichmentService?: CompanyEnrichmentService,
 ): StructuredToolInterface {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (tool as any)(
@@ -82,7 +88,7 @@ export function createCreateContractorTool(
       bankAccount,
       notes,
     }: {
-      name: string;
+      name?: string;
       nip?: string;
       regon?: string;
       email?: string;
@@ -97,6 +103,54 @@ export function createCreateContractorTool(
       try {
         const limitError = await checkWFirmaLimit(subscriptionService, userId, locale);
         if (limitError) return limitError;
+
+        const t = getContractorTranslations(locale);
+
+        // Auto-fill from public registry when NIP is provided and core fields are missing.
+        // Saves the user from re-typing what's already on Biała Lista MF.
+        const autoFilledFields: string[] = [];
+        if (
+          enrichmentService &&
+          nip &&
+          validateNip(nip) &&
+          (!name || !regon || !street || !city || !zip)
+        ) {
+          const enriched = await enrichmentService.enrichByNip(nip, userId);
+          if (enriched) {
+            if (!name && enriched.name) {
+              name = enriched.name;
+              autoFilledFields.push('name');
+            }
+            if (!regon && enriched.regon) {
+              regon = enriched.regon;
+              autoFilledFields.push('regon');
+            }
+            const sourceAddress = enriched.workingAddress || enriched.residenceAddress;
+            if (sourceAddress) {
+              const parsed = parsePolishAddress(sourceAddress);
+              if (!street && parsed.street) {
+                street = parsed.street;
+                autoFilledFields.push('street');
+              }
+              if (!city && parsed.city) {
+                city = parsed.city;
+                autoFilledFields.push('city');
+              }
+              if (!zip && parsed.zip) {
+                zip = parsed.zip;
+                autoFilledFields.push('zip');
+              }
+            }
+          }
+        }
+
+        if (!name || !name.trim()) {
+          return `## ❌ ${t.errorCreateTitle}
+
+**${t.errorReason}:** ${t.requiredFields}: name (and optionally NIP). When NIP is provided, name is auto-filled from the public registry — but here either no NIP was given or the NIP was not found.
+
+${t.tryAgain}`;
+        }
 
         const address = (street || city || zip || country)
           ? {
@@ -124,7 +178,7 @@ export function createCreateContractorTool(
 
         await cacheService.invalidateCache(userId, 'contractor');
 
-        return formatContractorCreated(contractor, locale);
+        return formatContractorCreated(contractor, locale, autoFilledFields);
       } catch (error) {
         logger.error('Failed to create contractor', { error });
         const t = getContractorTranslations(locale);
@@ -148,10 +202,21 @@ ${t.tryAgain}`;
     },
     {
       name: 'create_contractor',
-      description: 'Create a new contractor/customer in wFirma. Required: name. Recommended: city (city name). Optional: nip, regon, email, phone, street, zip, country (2-letter code like PL, LT), bankAccount, notes.',
+      description:
+        'Create a new contractor/customer in wFirma. Provide either `name` OR `nip` (when only NIP is given, name/REGON/address are auto-filled from the Polish public registry — Biała Lista MF). Optional: email, phone, street, city, zip, country (2-letter code like PL, LT), bankAccount, notes. The reply lists which fields were auto-filled.',
       schema: z.object({
-        name: z.string().describe('Full name or company name of the contractor (required)'),
-        nip: z.string().nullable().optional().describe('NIP (Polish tax ID) - 10 digits'),
+        name: z
+          .string()
+          .nullable()
+          .optional()
+          .describe(
+            'Full name or company name of the contractor. Optional only if NIP is provided — in that case it is auto-filled from the Polish public registry.',
+          ),
+        nip: z
+          .string()
+          .nullable()
+          .optional()
+          .describe('NIP (Polish tax ID) — 10 digits. When provided, missing fields (name, REGON, address) are auto-filled from Biała Lista MF.'),
         regon: z.string().nullable().optional().describe('REGON number'),
         email: z.string().nullable().optional().describe('Email address'),
         phone: z.string().nullable().optional().describe('Phone number'),

--- a/packages/api/src/services/ai-chat/tools/index.ts
+++ b/packages/api/src/services/ai-chat/tools/index.ts
@@ -262,7 +262,7 @@ export function createAllTools(
 
     // Contractor tools
     createGetContractorsTool(wfirmaService, locale, userId, subscriptionService),
-    createCreateContractorTool(wfirmaService, cacheService, userId, locale, subscriptionService),
+    createCreateContractorTool(wfirmaService, cacheService, userId, locale, subscriptionService, enrichmentService),
     createUpdateContractorTool(wfirmaService, cacheService, userId, locale, subscriptionService),
     createDeleteContractorTool(wfirmaService, cacheService, userId, locale, subscriptionService),
 

--- a/packages/api/src/services/company-enrichment.service.ts
+++ b/packages/api/src/services/company-enrichment.service.ts
@@ -13,6 +13,39 @@ const KRS_API_BASE = 'https://api-krs.ms.gov.pl';
 const API_TIMEOUT = 5000;
 
 /**
+ * Parse a Polish single-string address (as returned by MF Biała Lista) into
+ * street/city/zip components.
+ *
+ * Handles common forms:
+ *   "UL. PIĘKNA 47B/8, 00-672 WARSZAWA"
+ *   "PIĘKNA 47B/8 00-672 WARSZAWA"
+ *   "00-672 WARSZAWA, UL. PIĘKNA 47B/8"
+ *
+ * Best-effort. Anything we cannot identify as a postcode-anchored token goes
+ * into `street`. Returns an empty object if input is empty.
+ */
+export function parsePolishAddress(input: string): { street?: string; city?: string; zip?: string } {
+  if (!input) return {};
+  const zipPattern = /(\d{2}-\d{3})\s+([^,]+)/;
+  const match = input.match(zipPattern);
+  if (!match) {
+    return { street: input.trim() };
+  }
+  const zip = match[1];
+  const city = match[2].trim();
+  const street = input
+    .replace(match[0], '')
+    .replace(/[,\s]+$/, '')
+    .replace(/^[,\s]+/, '')
+    .trim();
+  return {
+    street: street || undefined,
+    city: city || undefined,
+    zip: zip || undefined,
+  };
+}
+
+/**
  * Validate Polish NIP with modulo 11 checksum
  */
 export function validateNip(nip: string): boolean {
@@ -74,11 +107,14 @@ export class CompanyEnrichmentService {
       // 3. Merge results
       const result: PublicRegistryData = {
         nip,
+        name: mfData?.name || undefined,
         regon: mfData?.regon || undefined,
         krs: mfData?.krs || undefined,
         vatStatus: mfData?.vatStatus || undefined,
         vatStatusDate: mfData?.vatStatusDate || undefined,
         verifiedBankAccounts: mfData?.verifiedBankAccounts || undefined,
+        workingAddress: mfData?.workingAddress || undefined,
+        residenceAddress: mfData?.residenceAddress || undefined,
         krsData: krsData || undefined,
       };
 
@@ -101,11 +137,14 @@ export class CompanyEnrichmentService {
    * GET https://wl-api.mf.gov.pl/api/search/nip/{nip}?date={YYYY-MM-DD}
    */
   private async fetchFromBialaLista(nip: string): Promise<{
+    name?: string;
     regon?: string;
     krs?: string;
     vatStatus?: PublicRegistryData['vatStatus'];
     vatStatusDate?: string;
     verifiedBankAccounts?: string[];
+    workingAddress?: string;
+    residenceAddress?: string;
   } | null> {
     const today = new Date().toISOString().split('T')[0];
     const url = `${MF_API_BASE}/api/search/nip/${nip}?date=${today}`;
@@ -121,12 +160,19 @@ export class CompanyEnrichmentService {
     }
 
     return {
+      name: typeof subject.name === 'string' && subject.name.trim() ? subject.name.trim() : undefined,
       regon: subject.regon || undefined,
       krs: subject.krs || undefined,
       vatStatus: this.mapVatStatus(subject.statusVat),
       vatStatusDate: subject.registrationDenialDate || subject.registrationLegalDate || undefined,
       verifiedBankAccounts: Array.isArray(subject.accountNumbers)
         ? subject.accountNumbers.filter((a: string) => a)
+        : undefined,
+      workingAddress: typeof subject.workingAddress === 'string' && subject.workingAddress.trim()
+        ? subject.workingAddress.trim()
+        : undefined,
+      residenceAddress: typeof subject.residenceAddress === 'string' && subject.residenceAddress.trim()
+        ? subject.residenceAddress.trim()
         : undefined,
     };
   }

--- a/packages/api/src/types/wfirma.types.ts
+++ b/packages/api/src/types/wfirma.types.ts
@@ -115,11 +115,17 @@ export interface KrsData {
 
 export interface PublicRegistryData {
   nip: string;
+  /** Full legal name from Biała Lista (subject.name) */
+  name?: string;
   regon?: string;
   krs?: string;
   vatStatus?: 'czynny' | 'zwolniony' | 'niezarejestrowany';
   vatStatusDate?: string;
   verifiedBankAccounts?: string[];
+  /** Address of business activity (workingAddress) — single-string form from MF */
+  workingAddress?: string;
+  /** Residence address (residenceAddress) — single-string form from MF */
+  residenceAddress?: string;
   krsData?: KrsData;
 }
 


### PR DESCRIPTION
## Summary

- \`create_contractor\` now accepts NIP-only input — \`name\`, \`REGON\`, \`street\`, \`city\`, \`zip\` are auto-filled from the Polish public registry (Biała Lista MF) via existing \`CompanyEnrichmentService.enrichByNip()\`.
- Confirmation card lists which fields were auto-filled so the user can spot mistakes before invoicing.
- \`fetchFromBialaLista\` now extracts \`subject.name\`, \`workingAddress\`, \`residenceAddress\` (previously only structural fields).
- New helper \`parsePolishAddress()\` — heuristic street/city/zip splitter for the single-string addresses MF returns.

## Scoping note

This implements the \"NIP → autofilled contractor\" UX value from #110 against the data we already get for free from Biała Lista. Full GUS BIR1.1 SOAP integration (which adds PKD codes and full address breakdown for sole proprietors not in KRS) is deferred — see comment on #110.

## Test plan

- [x] \`npm run test\` passes (16 tests in \`company-enrichment.service.test.ts\`, 8 new)
- [x] \`tsc --noEmit\` clean
- [x] eslint clean on touched files
- [ ] Manual: ask the agent in PL/EN/RU "create contractor for NIP 5833510147" — expect a populated contractor card with auto-filled fields listed
- [ ] Manual: ask "create contractor 'Acme' NIP 5833510147" — expect 'Acme' to win over registry name; address still auto-filled

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)