### PR TITLE
fix(help): align help-topic categories with UI tab IDs (Telegram, Organization)

### DIFF
--- a/packages/api/src/services/help-seed.service.ts
+++ b/packages/api/src/services/help-seed.service.ts
@@ -1242,7 +1242,7 @@ Data is automatically refreshed every 10 minutes. You can also refresh manually 
   },
   {
     slug: 'settings-organization',
-    category: 'settings',
+    category: 'organization',
     titlePl: 'Organizacja',
     titleEn: 'Organization',
     titleRu: 'Организация',
@@ -1461,7 +1461,7 @@ Only **active members** of the organization can see shared conversations. Users 
   },
   {
     slug: 'settings-telegram',
-    category: 'settings',
+    category: 'telegram',
     titlePl: 'Bot Telegram',
     titleEn: 'Telegram Bot',
     titleRu: 'Telegram-бот',
@@ -1575,7 +1575,7 @@ Telegram-бот позволяет использовать AI-ассистен�
   },
   {
     slug: 'ai-chat-receipt-ocr-telegram',
-    category: 'aiChat',
+    category: 'telegram',
     titlePl: 'Skanowanie paragonów w bocie Telegram',
     titleEn: 'Receipt scanning in the Telegram bot',
     titleRu: 'Сканирование чеков в Telegram-боте',


### PR DESCRIPTION
## The bug

Open the help panel → click **Telegram** or **Organization** tab → empty list. The tabs exist in the UI but show no content.

## Root cause

\`packages/web/src/components/help/HelpPanel.tsx\` defines tab IDs \`organization\` and \`telegram\` and filters via \`/api/help/topics?category=<id>\` with exact match. But \`packages/api/src/services/help-seed.service.ts\` was storing the relevant articles under category \`settings\`. The two never matched, so both tabs returned an empty list.

The recently added OCR article (#114) was also placed under \`aiChat\`, but it's specifically a Telegram-bot feature — users will look for it on the Telegram tab.

## Fix

Three slug → category remappings in the seed file:

- \`settings-organization\` : \`settings\` → \`organization\`
- \`settings-telegram\` : \`settings\` → \`telegram\`
- \`ai-chat-receipt-ocr-telegram\` : \`aiChat\` → \`telegram\`

\`seedHelpTopicsIfEmpty()\` upserts by slug on every API startup — the change applies in place to existing rows; no manual migration / SQL needed.

## Test plan

- [x] tsc clean
- [ ] Manual: restart API, open /help → Telegram tab shows two articles ("Bot Telegram", "Skanowanie paragonów w bocie Telegram")
- [ ] Manual: Organization tab shows the existing organization article
- [ ] Manual: aiChat tab no longer shows the OCR article (moved out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)