### PR TITLE
AIA-153 SEO: server-render landing, Polish meta, indexable en/ru (i18n routing)

### DIFF
--- a/packages/web/src/app/cookies/layout.tsx
+++ b/packages/web/src/app/cookies/layout.tsx
@@ -1,11 +1,26 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Polityka Plików Cookie',
-  description: 'Polityka plików cookie serwisu eKsięgowy AI.',
-  alternates: { canonical: '/cookies' },
-  openGraph: { title: 'Polityka Plików Cookie | eKsięgowy AI', url: '/cookies' },
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Polityka Plików Cookie',
+    description: 'Polityka plików cookie serwisu eKsięgowy AI.',
+  },
+  en: {
+    title: 'Cookie Policy',
+    description: 'Cookie policy of the eKsięgowy AI platform.',
+  },
+  ru: {
+    title: 'Политика использования cookie',
+    description: 'Политика использования файлов cookie сервиса eKsięgowy AI.',
+  },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/cookies', locale);
+}
 
 export default function CookiesLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/guide/ksef/get-tokens/layout.tsx
+++ b/packages/web/src/app/guide/ksef/get-tokens/layout.tsx
@@ -1,12 +1,29 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Jak uzyskać tokeny KSeF',
-  description:
-    'Wygeneruj token uwierzytelniający w portalu KSeF i podłącz go do eKsięgowy AI — instrukcja krok po kroku.',
-  alternates: { canonical: '/guide/ksef/get-tokens' },
-  openGraph: { title: 'Jak uzyskać tokeny KSeF | eKsięgowy AI', url: '/guide/ksef/get-tokens' },
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Jak uzyskać tokeny KSeF',
+    description:
+      'Wygeneruj token uwierzytelniający w portalu KSeF i podłącz go do eKsięgowy AI — instrukcja krok po kroku.',
+  },
+  en: {
+    title: 'How to Get KSeF Tokens',
+    description:
+      'Generate an authentication token in the KSeF portal and connect it to eKsięgowy AI — a step-by-step guide.',
+  },
+  ru: {
+    title: 'Как получить токены KSeF',
+    description:
+      'Сгенерируйте токен аутентификации в портале KSeF и подключите его к eKsięgowy AI — пошаговая инструкция.',
+  },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/guide/ksef/get-tokens', locale);
+}
 
 export default function GuideKsefTokensLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/guide/ksef/layout.tsx
+++ b/packages/web/src/app/guide/ksef/layout.tsx
@@ -1,12 +1,29 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Przewodnik KSeF',
-  description:
-    'Jak korzystać z Krajowego Systemu e-Faktur (KSeF) w eKsięgowy AI — wysyłka i odbiór e-faktur.',
-  alternates: { canonical: '/guide/ksef' },
-  openGraph: { title: 'Przewodnik KSeF | eKsięgowy AI', url: '/guide/ksef' },
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Przewodnik KSeF',
+    description:
+      'Jak korzystać z Krajowego Systemu e-Faktur (KSeF) w eKsięgowy AI — wysyłka i odbiór e-faktur.',
+  },
+  en: {
+    title: 'KSeF Guide',
+    description:
+      'How to use Poland’s National e-Invoicing System (KSeF) in eKsięgowy AI — sending and receiving e-invoices.',
+  },
+  ru: {
+    title: 'Руководство по KSeF',
+    description:
+      'Как использовать Национальную систему электронных фактур (KSeF) в eKsięgowy AI — отправка и получение e-фактур.',
+  },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/guide/ksef', locale);
+}
 
 export default function GuideKsefLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/guide/ksef/page.tsx
+++ b/packages/web/src/app/guide/ksef/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { ChevronRight, FileText } from 'lucide-react';
 import { useLocale } from '@/contexts/LocaleContext';
 import { GuidePageLayout } from '@/components/guide';

--- a/packages/web/src/app/guide/layout.tsx
+++ b/packages/web/src/app/guide/layout.tsx
@@ -1,12 +1,29 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Przewodnik',
-  description:
-    'Przewodniki krok po kroku, jak skonfigurować i korzystać z eKsięgowy AI — integracja z wFirma, KSeF i bot Telegram.',
-  alternates: { canonical: '/guide' },
-  openGraph: { title: 'Przewodnik | eKsięgowy AI', url: '/guide' },
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Przewodnik',
+    description:
+      'Przewodniki krok po kroku, jak skonfigurować i korzystać z eKsięgowy AI — integracja z wFirma, KSeF i bot Telegram.',
+  },
+  en: {
+    title: 'Guide',
+    description:
+      'Step-by-step guides on how to set up and use eKsięgowy AI — wFirma integration, KSeF and the Telegram bot.',
+  },
+  ru: {
+    title: 'Руководство',
+    description:
+      'Пошаговые руководства по настройке и использованию eKsięgowy AI — интеграция с wFirma, KSeF и бот Telegram.',
+  },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/guide', locale);
+}
 
 export default function GuideLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/guide/page.tsx
+++ b/packages/web/src/app/guide/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { ChevronRight } from 'lucide-react';
 import { useLocale } from '@/contexts/LocaleContext';
 import { GuidePageLayout } from '@/components/guide';

--- a/packages/web/src/app/guide/telegram/layout.tsx
+++ b/packages/web/src/app/guide/telegram/layout.tsx
@@ -1,12 +1,29 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Bot Telegram',
-  description:
-    'Skonfiguruj bota Telegram eKsięgowy AI — czat z asystentem AI na telefonie i skanowanie paragonów.',
-  alternates: { canonical: '/guide/telegram' },
-  openGraph: { title: 'Bot Telegram | eKsięgowy AI', url: '/guide/telegram' },
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Bot Telegram',
+    description:
+      'Skonfiguruj bota Telegram eKsięgowy AI — czat z asystentem AI na telefonie i skanowanie paragonów.',
+  },
+  en: {
+    title: 'Telegram Bot',
+    description:
+      'Set up the eKsięgowy AI Telegram bot — chat with the AI assistant on your phone and scan receipts.',
+  },
+  ru: {
+    title: 'Бот Telegram',
+    description:
+      'Настройте Telegram-бота eKsięgowy AI — общайтесь с ИИ-ассистентом на телефоне и сканируйте чеки.',
+  },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/guide/telegram', locale);
+}
 
 export default function GuideTelegramLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/guide/telegram/page.tsx
+++ b/packages/web/src/app/guide/telegram/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { ChevronRight, FileText } from 'lucide-react';
 import { useLocale } from '@/contexts/LocaleContext';
 import { GuidePageLayout } from '@/components/guide';

--- a/packages/web/src/app/guide/telegram/setup/layout.tsx
+++ b/packages/web/src/app/guide/telegram/setup/layout.tsx
@@ -1,15 +1,29 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Jak skonfigurować bota Telegram',
-  description:
-    'Połącz konto Telegram z eKsięgowy AI i zacznij korzystać z czatu AI na telefonie — instrukcja krok po kroku.',
-  alternates: { canonical: '/guide/telegram/setup' },
-  openGraph: {
-    title: 'Jak skonfigurować bota Telegram | eKsięgowy AI',
-    url: '/guide/telegram/setup',
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Jak skonfigurować bota Telegram',
+    description:
+      'Połącz konto Telegram z eKsięgowy AI i zacznij korzystać z czatu AI na telefonie — instrukcja krok po kroku.',
+  },
+  en: {
+    title: 'How to Set Up the Telegram Bot',
+    description:
+      'Link your Telegram account to eKsięgowy AI and start using AI chat on your phone — a step-by-step guide.',
+  },
+  ru: {
+    title: 'Как настроить бота Telegram',
+    description:
+      'Привяжите аккаунт Telegram к eKsięgowy AI и начните пользоваться ИИ-чатом на телефоне — пошаговая инструкция.',
   },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/guide/telegram/setup', locale);
+}
 
 export default function GuideTelegramSetupLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/guide/wfirma/get-api-credentials/layout.tsx
+++ b/packages/web/src/app/guide/wfirma/get-api-credentials/layout.tsx
@@ -1,15 +1,29 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Jak uzyskać dane API wFirma',
-  description:
-    'Wygeneruj dane uwierzytelniające API w wFirma i wklej je do eKsięgowy AI — instrukcja krok po kroku.',
-  alternates: { canonical: '/guide/wfirma/get-api-credentials' },
-  openGraph: {
-    title: 'Jak uzyskać dane API wFirma | eKsięgowy AI',
-    url: '/guide/wfirma/get-api-credentials',
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Jak uzyskać dane API wFirma',
+    description:
+      'Wygeneruj dane uwierzytelniające API w wFirma i wklej je do eKsięgowy AI — instrukcja krok po kroku.',
+  },
+  en: {
+    title: 'How to Get wFirma API Credentials',
+    description:
+      'Generate API credentials in wFirma and paste them into eKsięgowy AI — a step-by-step guide.',
+  },
+  ru: {
+    title: 'Как получить данные API wFirma',
+    description:
+      'Сгенерируйте учётные данные API в wFirma и вставьте их в eKsięgowy AI — пошаговая инструкция.',
   },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/guide/wfirma/get-api-credentials', locale);
+}
 
 export default function GuideWfirmaCredentialsLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/guide/wfirma/layout.tsx
+++ b/packages/web/src/app/guide/wfirma/layout.tsx
@@ -1,12 +1,29 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Integracja z wFirma',
-  description:
-    'Połącz eKsięgowy AI ze swoim kontem wFirma i zarządzaj fakturami oraz kontrahentami przez AI.',
-  alternates: { canonical: '/guide/wfirma' },
-  openGraph: { title: 'Integracja z wFirma | eKsięgowy AI', url: '/guide/wfirma' },
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Integracja z wFirma',
+    description:
+      'Połącz eKsięgowy AI ze swoim kontem wFirma i zarządzaj fakturami oraz kontrahentami przez AI.',
+  },
+  en: {
+    title: 'wFirma Integration',
+    description:
+      'Connect eKsięgowy AI to your wFirma account and manage invoices and contractors through AI.',
+  },
+  ru: {
+    title: 'Интеграция с wFirma',
+    description:
+      'Подключите eKsięgowy AI к своему аккаунту wFirma и управляйте фактурами и контрагентами через ИИ.',
+  },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/guide/wfirma', locale);
+}
 
 export default function GuideWfirmaLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/guide/wfirma/page.tsx
+++ b/packages/web/src/app/guide/wfirma/page.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { ChevronRight, FileText } from 'lucide-react';
 import { useLocale } from '@/contexts/LocaleContext';
 import { GuidePageLayout } from '@/components/guide';

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -13,11 +13,11 @@ import { GoogleAnalytics, MarketingAITracking } from '@/components/analytics';
 
 export const metadata: Metadata = {
   title: {
-    default: 'eKsięgowy AI — AI Accounting for Polish Businesses',
+    default: 'eKsięgowy AI — Księgowość AI dla polskich firm',
     template: '%s | eKsięgowy AI',
   },
   description:
-    'AI-powered accounting assistant for Polish businesses. Integrates with wFirma, supports KSeF e-invoices, and answers your tax questions about VAT, PIT, CIT, and ZUS.',
+    'Asystent księgowy oparty na AI dla polskich firm. Integruje się z wFirma, obsługuje e-faktury KSeF i odpowiada na pytania o VAT, PIT, CIT i ZUS.',
   keywords: [
     'accounting',
     'AI',
@@ -47,16 +47,16 @@ export const metadata: Metadata = {
     alternateLocale: ['en_US', 'ru_RU'],
     url: SITE_URL,
     siteName: SITE_NAME,
-    title: 'eKsięgowy AI — AI Accounting for Polish Businesses',
+    title: 'eKsięgowy AI — Księgowość AI dla polskich firm',
     description:
-      'Your intelligent accounting assistant that integrates with wFirma. Ask about VAT, PIT, CIT, ZUS, invoices, and more.',
+      'Twój inteligentny asystent księgowy zintegrowany z wFirma. Zapytaj o VAT, PIT, CIT, ZUS, faktury i więcej.',
     images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: SITE_NAME }],
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'eKsięgowy AI — AI Accounting for Polish Businesses',
+    title: 'eKsięgowy AI — Księgowość AI dla polskich firm',
     description:
-      'Your intelligent accounting assistant that integrates with wFirma. Ask about VAT, PIT, CIT, ZUS, invoices, and more.',
+      'Twój inteligentny asystent księgowy zintegrowany z wFirma. Zapytaj o VAT, PIT, CIT, ZUS, faktury i więcej.',
     images: ['/opengraph-image'],
   },
   robots: {

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -1,6 +1,16 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
-import { SITE_URL, SITE_NAME, ORGANIZATION_JSONLD, WEBSITE_JSONLD } from '@/lib/seo';
+import {
+  SITE_URL,
+  SITE_NAME,
+  ORGANIZATION_JSONLD,
+  WEBSITE_JSONLD,
+  alternatesFor,
+  LOCALE_BCP47,
+  LOCALES,
+  type Locale,
+} from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 import { JsonLd } from '@/components/seo/JsonLd';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { LocaleProvider } from '@/contexts/LocaleContext';
@@ -11,68 +21,87 @@ import { QueryProvider } from '@/components/providers/QueryProvider';
 import { CookieConsentBanner, CookiePreferencesModal } from '@/components/cookies';
 import { GoogleAnalytics, MarketingAITracking } from '@/components/analytics';
 
-export const metadata: Metadata = {
-  title: {
-    default: 'eKsięgowy AI — Księgowość AI dla polskich firm',
-    template: '%s | eKsięgowy AI',
-  },
-  description:
-    'Asystent księgowy oparty na AI dla polskich firm. Integruje się z wFirma, obsługuje e-faktury KSeF i odpowiada na pytania o VAT, PIT, CIT i ZUS.',
-  keywords: [
-    'accounting',
-    'AI',
-    'Poland',
-    'wFirma',
-    'KSeF',
-    'VAT',
-    'PIT',
-    'CIT',
-    'ZUS',
-    'invoices',
-    'eKsięgowy',
-    'księgowość',
-  ],
-  authors: [{ name: 'MICODE sp. z o.o.' }],
-  metadataBase: new URL(SITE_URL),
-  alternates: {
-    canonical: '/',
-    languages: {
-      'pl-PL': '/',
-      'x-default': '/',
-    },
-  },
-  openGraph: {
-    type: 'website',
-    locale: 'pl_PL',
-    alternateLocale: ['en_US', 'ru_RU'],
-    url: SITE_URL,
-    siteName: SITE_NAME,
+/** Localized homepage metadata (title + descriptions) keyed by locale. */
+const HOME_META: Record<Locale, { title: string; description: string; ogDescription: string }> = {
+  pl: {
     title: 'eKsięgowy AI — Księgowość AI dla polskich firm',
     description:
+      'Asystent księgowy oparty na AI dla polskich firm. Integruje się z wFirma, obsługuje e-faktury KSeF i odpowiada na pytania o VAT, PIT, CIT i ZUS.',
+    ogDescription:
       'Twój inteligentny asystent księgowy zintegrowany z wFirma. Zapytaj o VAT, PIT, CIT, ZUS, faktury i więcej.',
-    images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: SITE_NAME }],
   },
-  twitter: {
-    card: 'summary_large_image',
-    title: 'eKsięgowy AI — Księgowość AI dla polskich firm',
+  en: {
+    title: 'eKsięgowy AI — AI Accounting for Polish Businesses',
     description:
-      'Twój inteligentny asystent księgowy zintegrowany z wFirma. Zapytaj o VAT, PIT, CIT, ZUS, faktury i więcej.',
-    images: ['/opengraph-image'],
+      'AI-powered accounting assistant for Polish businesses. Integrates with wFirma, supports KSeF e-invoices, and answers your tax questions about VAT, PIT, CIT, and ZUS.',
+    ogDescription:
+      'Your intelligent accounting assistant that integrates with wFirma. Ask about VAT, PIT, CIT, ZUS, invoices, and more.',
   },
-  robots: {
-    index: true,
-    follow: true,
-  },
-  icons: {
-    icon: [
-      { url: '/logo.svg', type: 'image/svg+xml' },
-    ],
-    apple: [
-      { url: '/logo.svg', type: 'image/svg+xml' },
-    ],
-    shortcut: '/logo.svg',
+  ru: {
+    title: 'eKsięgowy AI — ИИ-бухгалтерия для польского бизнеса',
+    description:
+      'ИИ-ассистент бухгалтера для польских компаний. Интеграция с wFirma, поддержка e-фактур KSeF, ответы на вопросы о VAT, PIT, CIT и ZUS.',
+    ogDescription:
+      'Ваш умный бухгалтерский ассистент с интеграцией wFirma. Спросите про VAT, PIT, CIT, ZUS, фактуры и многое другое.',
   },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  const m = HOME_META[locale];
+
+  return {
+    title: {
+      default: m.title,
+      template: '%s | eKsięgowy AI',
+    },
+    description: m.description,
+    keywords: [
+      'accounting',
+      'AI',
+      'Poland',
+      'wFirma',
+      'KSeF',
+      'VAT',
+      'PIT',
+      'CIT',
+      'ZUS',
+      'invoices',
+      'eKsięgowy',
+      'księgowość',
+    ],
+    authors: [{ name: 'MICODE sp. z o.o.' }],
+    metadataBase: new URL(SITE_URL),
+    alternates: alternatesFor('/', locale),
+    openGraph: {
+      type: 'website',
+      locale: LOCALE_BCP47[locale].replace('-', '_'),
+      alternateLocale: LOCALES.filter((l) => l !== locale).map((l) =>
+        LOCALE_BCP47[l].replace('-', '_'),
+      ),
+      url: SITE_URL,
+      siteName: SITE_NAME,
+      title: m.title,
+      description: m.ogDescription,
+      images: [{ url: '/opengraph-image', width: 1200, height: 630, alt: SITE_NAME }],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: m.title,
+      description: m.ogDescription,
+      images: ['/opengraph-image'],
+    },
+    robots: {
+      index: true,
+      follow: true,
+    },
+    icons: {
+      icon: [{ url: '/logo.svg', type: 'image/svg+xml' }],
+      apple: [{ url: '/logo.svg', type: 'image/svg+xml' }],
+      shortcut: '/logo.svg',
+    },
+  };
+}
 
 export const viewport: Viewport = {
   themeColor: '#2563eb',
@@ -97,13 +126,15 @@ const themeScript = `
   })();
 `;
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const locale = await getRequestLocale();
+
   return (
-    <html lang="pl" suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning>
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeScript }} />
         <JsonLd data={ORGANIZATION_JSONLD} />
@@ -117,7 +148,7 @@ export default function RootLayout({
               <MarketingAITracking />
               <GoogleOAuthProvider>
                 <AuthProvider>
-                  <LocaleProvider>
+                  <LocaleProvider initialLocale={locale}>
                     {children}
                     <CookieConsentBanner />
                     <CookiePreferencesModal />

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -14,38 +14,6 @@ import {
   LandingFooter,
 } from '@/components/landing';
 
-function LoadingScreen() {
-  return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 via-white to-blue-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800">
-      <div className="text-center">
-        <div className="inline-block">
-          <svg
-            className="animate-spin h-12 w-12 text-blue-600"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <circle
-              className="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              strokeWidth="4"
-            />
-            <path
-              className="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            />
-          </svg>
-        </div>
-        <p className="mt-4 text-gray-600 dark:text-gray-400 font-medium">Loading...</p>
-      </div>
-    </div>
-  );
-}
-
 function LandingPage() {
   return (
     <div className="min-h-screen bg-white dark:bg-gray-900">
@@ -64,12 +32,12 @@ function LandingPage() {
 }
 
 export default function Home() {
-  const { isLoading, isAuthenticated } = useAuth();
+  const { isAuthenticated } = useAuth();
 
-  if (isLoading) {
-    return <LoadingScreen />;
-  }
-
+  // Authenticated users get the app shell. Everyone else (including the
+  // initial loading state and all crawlers, which never authenticate) gets the
+  // landing page — so the marketing content + JSON-LD are in the server HTML
+  // instead of being hidden behind a client-side auth gate.
   if (isAuthenticated) {
     return <ChatContainer />;
   }

--- a/packages/web/src/app/pricing/layout.tsx
+++ b/packages/web/src/app/pricing/layout.tsx
@@ -1,17 +1,35 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Cennik',
-  description:
-    'Wybierz plan eKsięgowy AI. Zacznij za darmo z własnym kluczem API lub przejdź na Pro, aby uzyskać kredyty AI w cenie i nielimitowany dostęp do wFirma.',
-  alternates: { canonical: '/pricing' },
-  openGraph: {
-    title: 'Cennik | eKsięgowy AI',
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Cennik',
     description:
+      'Wybierz plan eKsięgowy AI. Zacznij za darmo z własnym kluczem API lub przejdź na Pro, aby uzyskać kredyty AI w cenie i nielimitowany dostęp do wFirma.',
+    ogDescription:
       'Prosty, przejrzysty cennik. Zacznij za darmo lub przejdź na Pro z kredytami AI w cenie.',
-    url: '/pricing',
+  },
+  en: {
+    title: 'Pricing',
+    description:
+      'Choose your eKsięgowy AI plan. Start free with your own API key, or go Pro for included AI credits and unlimited wFirma access.',
+    ogDescription:
+      'Simple, transparent pricing. Start free or go Pro with AI credits included.',
+  },
+  ru: {
+    title: 'Тарифы',
+    description:
+      'Выберите тариф eKsięgowy AI. Начните бесплатно со своим ключом API или перейдите на Pro для AI-кредитов в комплекте и безлимитного доступа к wFirma.',
+    ogDescription:
+      'Простые и прозрачные тарифы. Начните бесплатно или перейдите на Pro с AI-кредитами в комплекте.',
   },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/pricing', locale);
+}
 
 export default function PricingLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/privacy-policy/layout.tsx
+++ b/packages/web/src/app/privacy-policy/layout.tsx
@@ -1,11 +1,26 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Polityka Prywatności',
-  description: 'Polityka prywatności serwisu eKsięgowy AI — jak przetwarzamy Twoje dane.',
-  alternates: { canonical: '/privacy-policy' },
-  openGraph: { title: 'Polityka Prywatności | eKsięgowy AI', url: '/privacy-policy' },
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Polityka Prywatności',
+    description: 'Polityka prywatności serwisu eKsięgowy AI — jak przetwarzamy Twoje dane.',
+  },
+  en: {
+    title: 'Privacy Policy',
+    description: 'Privacy policy of the eKsięgowy AI platform — how we process your data.',
+  },
+  ru: {
+    title: 'Политика конфиденциальности',
+    description: 'Политика конфиденциальности сервиса eKsięgowy AI — как мы обрабатываем ваши данные.',
+  },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/privacy-policy', locale);
+}
 
 export default function PrivacyPolicyLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/rodo/layout.tsx
+++ b/packages/web/src/app/rodo/layout.tsx
@@ -1,12 +1,29 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Klauzula Informacyjna RODO',
-  description:
-    'Klauzula informacyjna RODO (art. 13 i 14 RODO) serwisu eKsięgowy AI — informacje o przetwarzaniu danych osobowych.',
-  alternates: { canonical: '/rodo' },
-  openGraph: { title: 'Klauzula Informacyjna RODO | eKsięgowy AI', url: '/rodo' },
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Klauzula Informacyjna RODO',
+    description:
+      'Klauzula informacyjna RODO (art. 13 i 14 RODO) serwisu eKsięgowy AI — informacje o przetwarzaniu danych osobowych.',
+  },
+  en: {
+    title: 'GDPR Information Notice',
+    description:
+      'GDPR information notice (Art. 13 and 14 GDPR) of the eKsięgowy AI platform — information on personal data processing.',
+  },
+  ru: {
+    title: 'Информация об обработке данных (GDPR/RODO)',
+    description:
+      'Информационная оговорка GDPR/RODO (ст. 13 и 14) сервиса eKsięgowy AI — сведения об обработке персональных данных.',
+  },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/rodo', locale);
+}
 
 export default function RodoLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/app/sitemap.ts
+++ b/packages/web/src/app/sitemap.ts
@@ -1,10 +1,26 @@
 import type { MetadataRoute } from 'next';
-import { PUBLIC_PATHS, absoluteUrl } from '@/lib/seo';
+import {
+  PUBLIC_PATHS,
+  LOCALES,
+  LOCALE_BCP47,
+  DEFAULT_LOCALE,
+  absoluteUrl,
+  localizedPath,
+} from '@/lib/seo';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  return PUBLIC_PATHS.map((path) => ({
-    url: absoluteUrl(path),
-    changeFrequency: path === '/' ? 'weekly' : 'monthly',
-    priority: path === '/' ? 1 : path === '/pricing' ? 0.9 : 0.7,
-  }));
+  return PUBLIC_PATHS.map((path) => {
+    const languages: Record<string, string> = {};
+    for (const l of LOCALES) {
+      languages[LOCALE_BCP47[l]] = absoluteUrl(localizedPath(path, l));
+    }
+    languages['x-default'] = absoluteUrl(localizedPath(path, DEFAULT_LOCALE));
+
+    return {
+      url: absoluteUrl(path),
+      changeFrequency: path === '/' ? 'weekly' : 'monthly',
+      priority: path === '/' ? 1 : path === '/pricing' ? 0.9 : 0.7,
+      alternates: { languages },
+    };
+  });
 }

--- a/packages/web/src/app/terms/layout.tsx
+++ b/packages/web/src/app/terms/layout.tsx
@@ -1,11 +1,26 @@
 import { Metadata } from 'next';
+import { buildPageMetadata, type Locale, type PageMeta } from '@/lib/seo';
+import { getRequestLocale } from '@/lib/locale.server';
 
-export const metadata: Metadata = {
-  title: 'Regulamin',
-  description: 'Regulamin świadczenia usług serwisu eKsięgowy AI.',
-  alternates: { canonical: '/terms' },
-  openGraph: { title: 'Regulamin | eKsięgowy AI', url: '/terms' },
+const META: Record<Locale, PageMeta> = {
+  pl: {
+    title: 'Regulamin',
+    description: 'Regulamin świadczenia usług serwisu eKsięgowy AI.',
+  },
+  en: {
+    title: 'Terms of Service',
+    description: 'Terms of service for the eKsięgowy AI platform.',
+  },
+  ru: {
+    title: 'Условия использования',
+    description: 'Условия предоставления услуг сервиса eKsięgowy AI.',
+  },
 };
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getRequestLocale();
+  return buildPageMetadata(META, '/terms', locale);
+}
 
 export default function TermsLayout({ children }: { children: React.ReactNode }) {
   return <>{children}</>;

--- a/packages/web/src/components/LocaleLink.tsx
+++ b/packages/web/src/components/LocaleLink.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import Link from 'next/link';
+import { forwardRef, type ComponentProps } from 'react';
+import { useLocalizedHref } from '@/hooks/useLocalizedHref';
+
+type LocaleLinkProps = ComponentProps<typeof Link>;
+
+/**
+ * Drop-in replacement for `next/link` for PUBLIC/marketing pages that prefixes
+ * internal string hrefs with the active locale (`/pricing` -> `/en/pricing`),
+ * so navigating within the EN/RU site keeps the user in their language and
+ * crawlers can reach the localized URLs.
+ *
+ * Only string hrefs beginning with `/` are localized; external links, hashes
+ * (`#features`) and `UrlObject` hrefs pass through untouched.
+ *
+ * Do NOT use inside the authenticated app — those routes stay locale-agnostic.
+ */
+export const LocaleLink = forwardRef<HTMLAnchorElement, LocaleLinkProps>(
+  function LocaleLink({ href, ...rest }, ref) {
+    const localize = useLocalizedHref();
+    const localizedHref =
+      typeof href === 'string' && href.startsWith('/') ? localize(href) : href;
+    return <Link ref={ref} href={localizedHref} {...rest} />;
+  },
+);

--- a/packages/web/src/components/guide/Breadcrumbs.tsx
+++ b/packages/web/src/components/guide/Breadcrumbs.tsx
@@ -1,4 +1,4 @@
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { ChevronRight } from 'lucide-react';
 
 export interface BreadcrumbItem {

--- a/packages/web/src/components/guide/GuidePageLayout.tsx
+++ b/packages/web/src/components/guide/GuidePageLayout.tsx
@@ -1,8 +1,9 @@
 'use client';
 import React from 'react';
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { ArrowLeft } from 'lucide-react';
 import { useLocale, type Locale } from '@/contexts/LocaleContext';
+import { useLocaleSwitcher } from '@/hooks/useLocalizedHref';
 import { JsonLd } from '@/components/seo/JsonLd';
 import { absoluteUrl } from '@/lib/seo';
 import { Breadcrumbs, type BreadcrumbItem } from './Breadcrumbs';
@@ -21,7 +22,8 @@ const LOCALE_OPTIONS: { value: Locale; label: string }[] = [
 ];
 
 export function GuidePageLayout({ title, summary, breadcrumbs, children }: Props) {
-  const { locale, setLocale } = useLocale();
+  const { locale } = useLocale();
+  const switchLocale = useLocaleSwitcher();
 
   // BreadcrumbList structured data (only meaningful for multi-level trails)
   const breadcrumbJsonLd =
@@ -55,7 +57,7 @@ export function GuidePageLayout({ title, summary, breadcrumbs, children }: Props
           </div>
           <select
             value={locale}
-            onChange={(e) => setLocale(e.target.value as Locale)}
+            onChange={(e) => switchLocale(e.target.value as Locale)}
             className="px-2 py-1 text-xs font-medium rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-transparent cursor-pointer"
             aria-label="Language"
           >

--- a/packages/web/src/components/guide/__tests__/Breadcrumbs.test.tsx
+++ b/packages/web/src/components/guide/__tests__/Breadcrumbs.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import { Breadcrumbs } from '../Breadcrumbs';
 
+// Breadcrumbs renders LocaleLink, which reads the active locale via useLocale.
+// Pin it to the default (Polish, unprefixed) so internal hrefs stay canonical.
+jest.mock('@/contexts/LocaleContext', () => ({
+  useLocale: () => ({ locale: 'pl', setLocale: jest.fn() }),
+}));
+
 describe('Breadcrumbs', () => {
   it('renders all items with separators', () => {
     render(

--- a/packages/web/src/components/landing/CTASection.tsx
+++ b/packages/web/src/components/landing/CTASection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { useLocale } from '@/contexts/LocaleContext';
 import enTranslations from '@/i18n/locales/en.json';
 import plTranslations from '@/i18n/locales/pl.json';

--- a/packages/web/src/components/landing/HeroSection.tsx
+++ b/packages/web/src/components/landing/HeroSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { useLocale } from '@/contexts/LocaleContext';
 import { Button } from '@/components/ui/button';
 import enTranslations from '@/i18n/locales/en.json';

--- a/packages/web/src/components/landing/LandingFooter.tsx
+++ b/packages/web/src/components/landing/LandingFooter.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { useLocale } from '@/contexts/LocaleContext';
 import enTranslations from '@/i18n/locales/en.json';
 import plTranslations from '@/i18n/locales/pl.json';

--- a/packages/web/src/components/landing/LandingHeader.tsx
+++ b/packages/web/src/components/landing/LandingHeader.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { useState } from 'react';
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { useLocale, Locale } from '@/contexts/LocaleContext';
+import { useLocaleSwitcher } from '@/hooks/useLocalizedHref';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { Button } from '@/components/ui/button';
 import { Menu, X } from 'lucide-react';
@@ -19,7 +20,8 @@ const localeOptions: { value: Locale; label: string }[] = [
 ];
 
 export function LandingHeader() {
-  const { locale, setLocale } = useLocale();
+  const { locale } = useLocale();
+  const switchLocale = useLocaleSwitcher();
   const t = translations[locale].landing.nav;
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -64,7 +66,7 @@ export function LandingHeader() {
           {/* Locale switcher */}
           <select
             value={locale}
-            onChange={(e) => setLocale(e.target.value as Locale)}
+            onChange={(e) => switchLocale(e.target.value as Locale)}
             className="px-2 py-1 text-xs font-medium rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-transparent cursor-pointer mr-1"
           >
             {localeOptions.map((l) => (
@@ -138,7 +140,7 @@ export function LandingHeader() {
             <div className="flex items-center justify-between pt-2 border-t border-gray-200 dark:border-gray-700">
               <select
                 value={locale}
-                onChange={(e) => setLocale(e.target.value as Locale)}
+                onChange={(e) => switchLocale(e.target.value as Locale)}
                 className="px-2 py-1 text-xs font-medium rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-gray-700 dark:text-gray-300 focus:ring-2 focus:ring-blue-500 focus:border-transparent cursor-pointer"
               >
                 {localeOptions.map((l) => (

--- a/packages/web/src/components/landing/PricingPreviewSection.tsx
+++ b/packages/web/src/components/landing/PricingPreviewSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Suspense } from 'react';
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { Loader2 } from 'lucide-react';
 import { useLocale } from '@/contexts/LocaleContext';
 import { PricingPlans } from '@/components/subscription/PricingPlans';

--- a/packages/web/src/components/legal/LegalFooter.tsx
+++ b/packages/web/src/components/legal/LegalFooter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { useLocale } from '@/contexts/LocaleContext';
 import enTranslations from '@/i18n/locales/en.json';
 import plTranslations from '@/i18n/locales/pl.json';

--- a/packages/web/src/components/legal/LegalPageLayout.tsx
+++ b/packages/web/src/components/legal/LegalPageLayout.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import React from 'react';
-import Link from 'next/link';
+import { LocaleLink as Link } from '@/components/LocaleLink';
 import { ArrowLeft } from 'lucide-react';
 import { useLocale, Locale } from '@/contexts/LocaleContext';
+import { useLocaleSwitcher } from '@/hooks/useLocalizedHref';
 import { LegalFooter } from './LegalFooter';
 
 interface LegalPageLayoutProps {
@@ -12,7 +13,8 @@ interface LegalPageLayoutProps {
 }
 
 export function LegalPageLayout({ title, children }: LegalPageLayoutProps) {
-  const { locale, setLocale } = useLocale();
+  const { locale } = useLocale();
+  const switchLocale = useLocaleSwitcher();
   const locales: Locale[] = ['en', 'pl', 'ru'];
 
   return (
@@ -35,7 +37,7 @@ export function LegalPageLayout({ title, children }: LegalPageLayoutProps) {
             {locales.map((l) => (
               <button
                 key={l}
-                onClick={() => setLocale(l)}
+                onClick={() => switchLocale(l)}
                 className={`px-2 py-1 text-xs rounded uppercase font-medium transition-colors ${
                   locale === l
                     ? 'bg-blue-600 text-white'

--- a/packages/web/src/contexts/LocaleContext.tsx
+++ b/packages/web/src/contexts/LocaleContext.tsx
@@ -73,33 +73,47 @@ const LocaleContext = createContext<LocaleContextType | undefined>(undefined);
 
 interface LocaleProviderProps {
   children: React.ReactNode;
+  /**
+   * Locale resolved server-side from the URL (via middleware's `x-locale`
+   * header). When the URL carries an explicit `/en` or `/ru` prefix this is
+   * authoritative and overrides any stored preference, so a shared link always
+   * renders in its own language. Defaults to `pl` for unprefixed URLs.
+   */
+  initialLocale?: Locale;
 }
 
-export function LocaleProvider({ children }: LocaleProviderProps) {
+export function LocaleProvider({ children, initialLocale = DEFAULT_LOCALE }: LocaleProviderProps) {
   const { user } = useAuth();
-  const [locale, setLocaleState] = useState<Locale>(DEFAULT_LOCALE);
+  const [locale, setLocaleState] = useState<Locale>(initialLocale);
   const [isInitialized, setIsInitialized] = useState(false);
 
   /**
-   * Initialize locale on mount
-   * Priority: 1. localStorage, 2. browser preference, 3. default
+   * Initialize locale on mount.
+   * If the URL explicitly selected a non-default locale (e.g. /en/pricing),
+   * that wins and is persisted. Otherwise fall back to the stored preference,
+   * then the browser language, then the default.
    */
   useEffect(() => {
     if (isInitialized) return;
 
-    const storedLocale = getStoredLocale();
-    if (storedLocale) {
-      setLocaleState(storedLocale);
+    if (initialLocale !== DEFAULT_LOCALE) {
+      // Explicit /en or /ru URL — authoritative.
+      saveLocale(initialLocale);
     } else {
-      const browserLocale = getBrowserLocale();
-      if (browserLocale) {
-        setLocaleState(browserLocale);
-        saveLocale(browserLocale);
+      const storedLocale = getStoredLocale();
+      if (storedLocale) {
+        setLocaleState(storedLocale);
+      } else {
+        const browserLocale = getBrowserLocale();
+        if (browserLocale) {
+          setLocaleState(browserLocale);
+          saveLocale(browserLocale);
+        }
       }
     }
 
     setIsInitialized(true);
-  }, [isInitialized]);
+  }, [isInitialized, initialLocale]);
 
   /**
    * Sync locale when user changes (e.g., login)

--- a/packages/web/src/hooks/useLocalizedHref.ts
+++ b/packages/web/src/hooks/useLocalizedHref.ts
@@ -1,0 +1,51 @@
+'use client';
+
+import { useCallback } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
+import { useLocale } from '@/contexts/LocaleContext';
+import { localizedPath, type Locale } from '@/lib/seo';
+
+/**
+ * Locale-aware link/navigation helpers for the public (pre-login) site.
+ *
+ * Because the locale-routing middleware rewrites `/en/*` and `/ru/*` onto the
+ * flat page tree, `usePathname()` always returns the UNPREFIXED canonical path
+ * (e.g. `/pricing` even when the visible URL is `/en/pricing`). That makes it
+ * the perfect base for building locale-prefixed targets.
+ *
+ *   const localize = useLocalizedHref();
+ *   <Link href={localize('/pricing')}>…</Link>   // -> /en/pricing on the EN site
+ *
+ *   const switchLocale = useLocaleSwitcher();
+ *   switchLocale('ru');                           // navigates to the RU URL of the current page
+ */
+export function useLocalizedHref() {
+  const { locale } = useLocale();
+
+  return useCallback(
+    (path: string) => localizedPath(path, locale),
+    [locale],
+  );
+}
+
+/**
+ * Returns a callback that switches the active locale by NAVIGATING to the
+ * localized URL of the current page, so the address bar reflects the language
+ * (and the server re-renders locale-correct metadata) rather than only flipping
+ * client state.
+ */
+export function useLocaleSwitcher() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { setLocale } = useLocale();
+
+  return useCallback(
+    (newLocale: Locale) => {
+      // pathname is already unprefixed thanks to the middleware rewrite.
+      const target = localizedPath(pathname || '/', newLocale);
+      setLocale(newLocale);
+      router.push(target);
+    },
+    [pathname, router, setLocale],
+  );
+}

--- a/packages/web/src/lib/locale.server.ts
+++ b/packages/web/src/lib/locale.server.ts
@@ -1,0 +1,13 @@
+import 'server-only';
+import { headers } from 'next/headers';
+import { DEFAULT_LOCALE, LOCALES, type Locale } from '@/lib/seo';
+
+/**
+ * Resolve the active request locale from the `x-locale` header set by the
+ * locale-routing middleware. Server-only — used by the root layout and by each
+ * public page's generateMetadata to emit locale-correct canonical + hreflang.
+ */
+export async function getRequestLocale(): Promise<Locale> {
+  const value = (await headers()).get('x-locale');
+  return (LOCALES as string[]).includes(value ?? '') ? (value as Locale) : DEFAULT_LOCALE;
+}

--- a/packages/web/src/lib/seo.ts
+++ b/packages/web/src/lib/seo.ts
@@ -1,9 +1,10 @@
 /**
  * Centralised SEO configuration and JSON-LD structured-data builders.
  *
- * i18n strategy (pragmatic): the Polish version is the canonical, server-rendered
- * one (primary market). en/ru remain client-side via LocaleContext. Metadata and
- * structured data below are therefore authored in Polish.
+ * i18n strategy (localePrefix: as-needed): Polish is the default and canonical
+ * language served on unprefixed URLs (e.g. /pricing). English and Russian are
+ * served on prefixed URLs (/en/pricing, /ru/pricing) via middleware rewrite, and
+ * every public page advertises the full hreflang trio so all three are indexable.
  */
 
 export const SITE_URL = (
@@ -11,6 +12,78 @@ export const SITE_URL = (
 ).replace(/\/$/, '');
 
 export const SITE_NAME = 'eKsięgowy AI';
+
+// ============================================
+// Locale routing (as-needed prefixing)
+// ============================================
+
+export type Locale = 'pl' | 'en' | 'ru';
+
+/** All supported locales. Polish is the default (unprefixed). */
+export const LOCALES: Locale[] = ['pl', 'en', 'ru'];
+
+/** The default locale, served on unprefixed URLs and used as x-default. */
+export const DEFAULT_LOCALE: Locale = 'pl';
+
+/** Locales that carry a URL prefix (everything except the default). */
+export const PREFIXED_LOCALES: Locale[] = ['en', 'ru'];
+
+/** BCP-47 tags for hreflang / og:locale, keyed by our short locale codes. */
+export const LOCALE_BCP47: Record<Locale, string> = {
+  pl: 'pl-PL',
+  en: 'en-US',
+  ru: 'ru-RU',
+};
+
+function isLocale(value: string): value is Locale {
+  return (LOCALES as string[]).includes(value);
+}
+
+/**
+ * Build the locale-aware path for a canonical (unprefixed) path.
+ * Polish stays unprefixed; en/ru get a `/en` or `/ru` prefix.
+ *   localizedPath('/pricing', 'en') -> '/en/pricing'
+ *   localizedPath('/', 'ru')        -> '/ru'
+ *   localizedPath('/pricing', 'pl') -> '/pricing'
+ */
+export function localizedPath(path: string, locale: Locale): string {
+  const clean = path === '/' ? '' : path.replace(/\/$/, '');
+  if (locale === DEFAULT_LOCALE) return clean || '/';
+  return `/${locale}${clean}`;
+}
+
+/**
+ * Strip a leading locale prefix from a pathname, returning the canonical
+ * (unprefixed) path plus the detected locale.
+ *   splitLocale('/en/pricing') -> { locale: 'en', path: '/pricing' }
+ *   splitLocale('/pricing')    -> { locale: 'pl', path: '/pricing' }
+ */
+export function splitLocale(pathname: string): { locale: Locale; path: string } {
+  const segments = pathname.split('/');
+  const maybe = segments[1];
+  if (maybe && isLocale(maybe) && maybe !== DEFAULT_LOCALE) {
+    const path = '/' + segments.slice(2).join('/');
+    return { locale: maybe, path: path === '/' ? '/' : path.replace(/\/$/, '') };
+  }
+  return { locale: DEFAULT_LOCALE, path: pathname === '/' ? '/' : pathname.replace(/\/$/, '') };
+}
+
+/**
+ * hreflang alternates for a canonical path, ready to drop into a Metadata
+ * `alternates` block. Includes a self-referencing canonical for the given
+ * locale plus the full pl/en/ru + x-default language map.
+ */
+export function alternatesFor(path: string, locale: Locale) {
+  const languages: Record<string, string> = {};
+  for (const l of LOCALES) {
+    languages[LOCALE_BCP47[l]] = localizedPath(path, l);
+  }
+  languages['x-default'] = localizedPath(path, DEFAULT_LOCALE);
+  return {
+    canonical: localizedPath(path, locale),
+    languages,
+  };
+}
 
 /** Routes that must never be indexed (auth-gated or API). Used by robots.ts. */
 export const PRIVATE_PATHS = [

--- a/packages/web/src/lib/seo.ts
+++ b/packages/web/src/lib/seo.ts
@@ -125,6 +125,53 @@ export function absoluteUrl(path: string): string {
 }
 
 // ============================================
+// Per-page localized metadata builder
+// ============================================
+
+/** Localized copy for a single public page, keyed by locale. */
+export interface PageMeta {
+  title: string;
+  description: string;
+  /** Optional OG title override; falls back to `${title} | ${SITE_NAME}`. */
+  ogTitle?: string;
+  /** Optional OG description override; falls back to `description`. */
+  ogDescription?: string;
+}
+
+/**
+ * Build a locale-correct Metadata fragment for a public subpage.
+ *
+ * Given the page's per-locale copy and the canonical (unprefixed) path, this
+ * sets the right title/description for the active locale, a self-referencing
+ * canonical plus the full hreflang trio (+ x-default), and a localized
+ * openGraph block whose `url` points at the locale-prefixed page.
+ *
+ *   export async function generateMetadata(): Promise<Metadata> {
+ *     const locale = await getRequestLocale();
+ *     return buildPageMetadata(PRICING_META, '/pricing', locale);
+ *   }
+ */
+export function buildPageMetadata(
+  meta: Record<Locale, PageMeta>,
+  path: string,
+  locale: Locale,
+) {
+  const m = meta[locale];
+  const ogTitle = m.ogTitle ?? `${m.title} | ${SITE_NAME}`;
+  const ogDescription = m.ogDescription ?? m.description;
+  return {
+    title: m.title,
+    description: m.description,
+    alternates: alternatesFor(path, locale),
+    openGraph: {
+      title: ogTitle,
+      description: ogDescription,
+      url: localizedPath(path, locale),
+    },
+  };
+}
+
+// ============================================
 // Organization (legal entity behind the service)
 // ============================================
 

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * Locale routing middleware (localePrefix: as-needed).
+ *
+ * Polish is the default and is served on unprefixed URLs (/pricing). English and
+ * Russian are served on prefixed URLs (/en/pricing, /ru/pricing); we rewrite
+ * those internally to the existing flat page tree and pass the active locale to
+ * the server via the `x-locale` request header (read by the root layout and by
+ * each page's generateMetadata). A `NEXT_LOCALE` cookie persists the choice for
+ * client-side navigation.
+ *
+ * The canonical Polish URLs are left completely untouched, so existing indexed
+ * pages keep their URLs. `/pl/*` is 308-redirected to the unprefixed form to
+ * avoid duplicate content.
+ */
+
+const DEFAULT_LOCALE = 'pl';
+const PREFIXED_LOCALES = ['en', 'ru'];
+
+function withLocaleHeader(req: NextRequest, locale: string, rewriteTo?: URL) {
+  const requestHeaders = new Headers(req.headers);
+  requestHeaders.set('x-locale', locale);
+
+  const res = rewriteTo
+    ? NextResponse.rewrite(rewriteTo, { request: { headers: requestHeaders } })
+    : NextResponse.next({ request: { headers: requestHeaders } });
+
+  if (locale !== DEFAULT_LOCALE) {
+    res.cookies.set('NEXT_LOCALE', locale, { path: '/', sameSite: 'lax' });
+  }
+  return res;
+}
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const segments = pathname.split('/');
+  const maybeLocale = segments[1];
+
+  // /en/* or /ru/*  ->  rewrite to the flat (unprefixed) path, signal locale.
+  if (PREFIXED_LOCALES.includes(maybeLocale)) {
+    const rest = '/' + segments.slice(2).join('/');
+    const url = req.nextUrl.clone();
+    url.pathname = rest === '/' ? '/' : rest.replace(/\/$/, '');
+    return withLocaleHeader(req, maybeLocale, url);
+  }
+
+  // /pl/*  ->  308-redirect to the canonical unprefixed URL (no duplicate content).
+  if (maybeLocale === DEFAULT_LOCALE) {
+    const rest = '/' + segments.slice(2).join('/');
+    const url = req.nextUrl.clone();
+    url.pathname = rest === '/' ? '/' : rest.replace(/\/$/, '');
+    return NextResponse.redirect(url, 308);
+  }
+
+  // Unprefixed (Polish default): pass through, but tell the server it's pl.
+  return withLocaleHeader(req, DEFAULT_LOCALE);
+}
+
+export const config = {
+  // Run on everything except API routes, Next internals, and static files.
+  matcher: ['/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)'],
+};


### PR DESCRIPTION
Closes part of #153 (SEO & marketing).

## What's in this PR

### 🔴 Quick wins
- **Server-render the landing page** — removed the `isLoading` spinner gate in `app/page.tsx`. The hero, features, pricing and `SoftwareApplication` JSON-LD are now in the server-rendered HTML (crawlers and social scrapers previously only saw "Loading…"). Authenticated users still get the chat shell.
- **Polish homepage metadata** — title/description and OG/Twitter copy switched from English to Polish to match the primary market.

### 🟠 en/ru are now indexable (`localePrefix: as-needed`)
- `middleware.ts`: `/en/*` and `/ru/*` are rewritten onto the flat page tree, with the active locale passed to the server via an `x-locale` request header. Polish stays the unprefixed canonical. `/pl/*` 308-redirects to the unprefixed URL (no duplicate content).
- Every public page now emits a self-referencing canonical + full hreflang trio (pl-PL/en-US/ru-RU/x-default), a correct `<html lang>`, and locale-correct content already in SSR.
- `sitemap.ts`: 13 paths × 4 hreflang each.
- Locale-aware navigation (`LocaleLink`, `useLocalizedHref`, `useLocaleSwitcher`) — the public language switcher `router.push`es the localized URL so the address bar and server-rendered metadata follow the language. Authenticated-app links are untouched.
- Existing Polish URLs are **unchanged** — no redirects required.

## Verification
Validated via `next dev` + live HTTP requests: `/`, `/en`, `/ru`, `/en/pricing`, `/ru/guide/ksef/get-tokens` serve the correct `lang`/`title`/H1/canonical/hreflang in SSR; `/pl*` → 308. `tsc --noEmit` clean on all changed files. Full web Jest suite green (9 suites / 39 tests) after updating the Breadcrumbs test for its new locale-context dependency.

> ⚠️ Local `next build` fails on a **pre-existing** recharts error (`CostChart.tsx`) unrelated to this PR — a known local-vs-CI discrepancy; CI is authoritative.

## Follow-ups (separate PRs, see #153)
No-API-key demo · content hub / blog · public tax-calendar page · public help center · FAQ/HowTo schema · social proof + product screenshots · referral promotion · "Security & Data" trust section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
