### PR TITLE
feat(seo/geo): generative-engine optimization for the blog & guides

### DIFF
--- a/packages/web/src/app/blog/[slug]/page.tsx
+++ b/packages/web/src/app/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { getRequestLocale } from '@/lib/locale.server';
 import {
   SITE_NAME,
   LOCALE_BCP47,
+  ARTICLE_AUTHOR,
   blogAlternatesFor,
   blogPostingJsonLd,
   faqPageJsonLd,
@@ -77,7 +78,9 @@ export default async function BlogArticlePage({ params }: Params) {
           locale,
           publishedAt: post.publishedAt,
           updatedAt: post.updatedAt,
-          author: post.author,
+          author: ARTICLE_AUTHOR.name,
+          authorUrl: ARTICLE_AUTHOR.url,
+          authorJobTitle: ARTICLE_AUTHOR.jobTitle,
           coverImage: post.coverImage,
           keywords: post.tags,
           section: post.category,
@@ -114,7 +117,7 @@ export default async function BlogArticlePage({ params }: Params) {
           {post.title}
         </h1>
         <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
-          {post.author}
+          {ARTICLE_AUTHOR.name}
           {dateLabel && (
             <>
               {' · '}

--- a/packages/web/src/app/blog/[slug]/page.tsx
+++ b/packages/web/src/app/blog/[slug]/page.tsx
@@ -66,6 +66,7 @@ export default async function BlogArticlePage({ params }: Params) {
 
   const isDraft = post.status === 'draft';
 
+  const wordCount = post.body.split(/\s+/).filter(Boolean).length;
   const jsonLd: Record<string, unknown>[] = isDraft
     ? []
     : [
@@ -78,6 +79,9 @@ export default async function BlogArticlePage({ params }: Params) {
           updatedAt: post.updatedAt,
           author: post.author,
           coverImage: post.coverImage,
+          keywords: post.tags,
+          section: post.category,
+          wordCount,
         }),
       ];
   if (!isDraft && post.faq && post.faq.length > 0) jsonLd.push(faqPageJsonLd(post.faq));

--- a/packages/web/src/app/blog/[slug]/page.tsx
+++ b/packages/web/src/app/blog/[slug]/page.tsx
@@ -80,6 +80,7 @@ export default async function BlogArticlePage({ params }: Params) {
           updatedAt: post.updatedAt,
           author: ARTICLE_AUTHOR.name,
           authorUrl: ARTICLE_AUTHOR.url,
+          authorSameAs: ARTICLE_AUTHOR.sameAs,
           authorJobTitle: ARTICLE_AUTHOR.jobTitle,
           coverImage: post.coverImage,
           keywords: post.tags,

--- a/packages/web/src/app/guide/ksef/get-tokens/page.tsx
+++ b/packages/web/src/app/guide/ksef/get-tokens/page.tsx
@@ -28,6 +28,7 @@ export default function GetTokensPage() {
         { label: topic.title, href: '/guide/ksef' },
         { label: article.title },
       ]}
+      howToSteps={article.steps.map((s) => ({ name: s.title, text: s.body }))}
     >
       <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{article.intro}</p>
 

--- a/packages/web/src/app/guide/telegram/setup/page.tsx
+++ b/packages/web/src/app/guide/telegram/setup/page.tsx
@@ -27,6 +27,7 @@ export default function TelegramSetupArticlePage() {
         { label: topic.title, href: '/guide/telegram' },
         { label: article.title },
       ]}
+      howToSteps={article.steps.map((s) => ({ name: s.title, text: s.body }))}
     >
       <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{article.intro}</p>
 

--- a/packages/web/src/app/guide/wfirma/get-api-credentials/page.tsx
+++ b/packages/web/src/app/guide/wfirma/get-api-credentials/page.tsx
@@ -28,6 +28,7 @@ export default function GetApiCredentialsPage() {
         { label: topic.title, href: '/guide/wfirma' },
         { label: article.title },
       ]}
+      howToSteps={article.steps.map((s) => ({ name: s.title, text: s.body }))}
     >
       <p className="text-gray-700 dark:text-gray-300 leading-relaxed">{article.intro}</p>
 

--- a/packages/web/src/app/llms.txt/route.ts
+++ b/packages/web/src/app/llms.txt/route.ts
@@ -1,0 +1,30 @@
+import { buildLlmsTxt, type LlmsArticle } from '@/lib/seo';
+import { getAllPublished } from '@/lib/blog/content';
+
+/**
+ * `/llms.txt` — an AI/LLM crawler guide (llmstxt.org convention). Serves a
+ * link-first Markdown overview of the product and its published articles so
+ * generative engines can discover and cite the most useful pages.
+ *
+ * Articles come from the canonical Polish content, newest-first. A read error
+ * degrades to an article-less document rather than a 500.
+ */
+export function GET(): Response {
+  let articles: LlmsArticle[] = [];
+  try {
+    articles = getAllPublished('pl').map((p) => ({
+      title: p.title,
+      slug: p.slug,
+      description: p.description,
+    }));
+  } catch {
+    articles = [];
+  }
+
+  return new Response(buildLlmsTxt(articles), {
+    headers: {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+    },
+  });
+}

--- a/packages/web/src/app/robots.test.ts
+++ b/packages/web/src/app/robots.test.ts
@@ -1,0 +1,35 @@
+import robots from './robots';
+import { SITE_URL, PRIVATE_PATHS } from '@/lib/seo';
+
+describe('robots', () => {
+  const result = robots();
+  const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+  const agents = rules.flatMap((r) => (Array.isArray(r.userAgent) ? r.userAgent : [r.userAgent]));
+
+  it('keeps the wildcard rule and the sitemap + host', () => {
+    expect(agents).toContain('*');
+    expect(result.sitemap).toBe(`${SITE_URL}/sitemap.xml`);
+    expect(result.host).toBe(SITE_URL);
+  });
+
+  it('explicitly allows the major AI answer-engine / training crawlers', () => {
+    for (const bot of [
+      'GPTBot',
+      'OAI-SearchBot',
+      'ChatGPT-User',
+      'ClaudeBot',
+      'PerplexityBot',
+      'Google-Extended',
+      'CCBot',
+    ]) {
+      expect(agents).toContain(bot);
+    }
+  });
+
+  it('disallows the private paths and allows the root for every rule', () => {
+    for (const r of rules) {
+      expect(r.allow).toBe('/');
+      expect(r.disallow).toEqual(PRIVATE_PATHS);
+    }
+  });
+});

--- a/packages/web/src/app/robots.ts
+++ b/packages/web/src/app/robots.ts
@@ -1,13 +1,35 @@
 import type { MetadataRoute } from 'next';
 import { SITE_URL, PRIVATE_PATHS } from '@/lib/seo';
 
+/**
+ * AI answer-engine and training crawlers we explicitly welcome (GEO). They get
+ * the same access as any other bot — the public site, minus the auth-gated
+ * paths — but stating it outright makes the intent unambiguous and keeps them
+ * allowed even if the wildcard policy is ever tightened.
+ */
+const AI_CRAWLERS = [
+  'GPTBot', // OpenAI crawler (training + search index)
+  'OAI-SearchBot', // ChatGPT search index
+  'ChatGPT-User', // ChatGPT live browsing on user request
+  'ClaudeBot', // Anthropic crawler
+  'Claude-User', // Claude live browsing on user request
+  'anthropic-ai', // legacy Anthropic agent
+  'PerplexityBot', // Perplexity index
+  'Perplexity-User', // Perplexity live fetch
+  'Google-Extended', // Gemini / Vertex grounding + training
+  'Applebot-Extended', // Apple Intelligence
+  'CCBot', // Common Crawl (feeds many LLMs)
+];
+
 export default function robots(): MetadataRoute.Robots {
+  const allowAllButPrivate = (userAgent: string | string[]) => ({
+    userAgent,
+    allow: '/',
+    disallow: PRIVATE_PATHS,
+  });
+
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-      disallow: PRIVATE_PATHS,
-    },
+    rules: [allowAllButPrivate('*'), allowAllButPrivate(AI_CRAWLERS)],
     sitemap: `${SITE_URL}/sitemap.xml`,
     host: SITE_URL,
   };

--- a/packages/web/src/components/guide/GuidePageLayout.tsx
+++ b/packages/web/src/components/guide/GuidePageLayout.tsx
@@ -5,13 +5,15 @@ import { ArrowLeft } from 'lucide-react';
 import { useLocale, type Locale } from '@/contexts/LocaleContext';
 import { useLocaleSwitcher } from '@/hooks/useLocalizedHref';
 import { JsonLd } from '@/components/seo/JsonLd';
-import { absoluteUrl } from '@/lib/seo';
+import { absoluteUrl, howToJsonLd } from '@/lib/seo';
 import { Breadcrumbs, type BreadcrumbItem } from './Breadcrumbs';
 
 interface Props {
   title: string;
   summary?: string;
   breadcrumbs: BreadcrumbItem[];
+  /** Ordered steps for a procedural guide; when set, emits HowTo structured data. */
+  howToSteps?: { name: string; text: string }[];
   children: React.ReactNode;
 }
 
@@ -21,7 +23,7 @@ const LOCALE_OPTIONS: { value: Locale; label: string }[] = [
   { value: 'ru', label: 'RU' },
 ];
 
-export function GuidePageLayout({ title, summary, breadcrumbs, children }: Props) {
+export function GuidePageLayout({ title, summary, breadcrumbs, howToSteps, children }: Props) {
   const { locale } = useLocale();
   const switchLocale = useLocaleSwitcher();
 
@@ -40,9 +42,16 @@ export function GuidePageLayout({ title, summary, breadcrumbs, children }: Props
         }
       : null;
 
+  // HowTo structured data for procedural guides (surfaced by AI answer engines).
+  const howTo =
+    howToSteps && howToSteps.length > 0
+      ? howToJsonLd({ name: title, description: summary, steps: howToSteps })
+      : null;
+
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col">
       {breadcrumbJsonLd && <JsonLd data={breadcrumbJsonLd} />}
+      {howTo && <JsonLd data={howTo} />}
       <header className="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 sticky top-0 z-10">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 py-4 flex items-center justify-between">
           <div className="flex items-center gap-4">

--- a/packages/web/src/components/guide/__tests__/GuidePageLayout.test.tsx
+++ b/packages/web/src/components/guide/__tests__/GuidePageLayout.test.tsx
@@ -1,0 +1,53 @@
+import { render } from '@testing-library/react';
+import { GuidePageLayout } from '../GuidePageLayout';
+
+// GuidePageLayout reads the active locale (LocaleLink + switcher). Pin them so
+// the component renders without the full provider tree.
+jest.mock('@/contexts/LocaleContext', () => ({
+  useLocale: () => ({ locale: 'pl', setLocale: jest.fn() }),
+}));
+jest.mock('@/hooks/useLocalizedHref', () => ({
+  useLocaleSwitcher: () => jest.fn(),
+  useLocalizedHref: () => (href: string) => href,
+}));
+
+function ldScripts(): string[] {
+  return Array.from(document.querySelectorAll('script[type="application/ld+json"]')).map(
+    (s) => s.innerHTML,
+  );
+}
+
+describe('GuidePageLayout HowTo structured data', () => {
+  it('emits HowTo JSON-LD with the steps when howToSteps is provided', () => {
+    render(
+      <GuidePageLayout
+        title="Get KSeF tokens"
+        summary="How to get tokens."
+        breadcrumbs={[{ label: 'Guide', href: '/guide' }, { label: 'KSeF' }]}
+        howToSteps={[
+          { name: 'Log in', text: 'Sign in.' },
+          { name: 'Generate', text: 'Create token.' },
+        ]}
+      >
+        <p>content</p>
+      </GuidePageLayout>,
+    );
+    const howTo = ldScripts().find((s) => s.includes('"HowTo"'));
+    expect(howTo).toBeDefined();
+    expect(howTo).toContain('Get KSeF tokens');
+    expect(howTo).toContain('HowToStep');
+    expect(howTo).toContain('Log in');
+  });
+
+  it('emits no HowTo JSON-LD when howToSteps is omitted', () => {
+    render(
+      <GuidePageLayout
+        title="Overview"
+        breadcrumbs={[{ label: 'Guide', href: '/guide' }, { label: 'KSeF' }]}
+      >
+        <p>content</p>
+      </GuidePageLayout>,
+    );
+    expect(ldScripts().some((s) => s.includes('"HowTo"'))).toBe(false);
+  });
+});

--- a/packages/web/src/lib/blog/content.test.ts
+++ b/packages/web/src/lib/blog/content.test.ts
@@ -7,6 +7,7 @@ import {
   getTranslations,
   getAllPosts,
   getAnyPostBySlug,
+  parseFaqFromBody,
 } from './content';
 
 let base: string;
@@ -62,6 +63,61 @@ publishedAt: 2026-07-10
 ---
 # Body EN`;
 
+// Mirrors the real article shape: a FAQ heading containing "FAQ", bolded
+// questions, answer paragraphs (with inline bold + a link), terminated by a
+// `---` thematic break before the disclaimer. Placed under `en` so it doesn't
+// disturb the getAllPublished('pl') / getTranslations('grp') assertions above.
+const PUB_WITH_FAQ = `---
+slug: withfaq
+locale: en
+translationKey: grpfaq
+title: With FAQ
+description: d
+category: VAT
+status: published
+publishedAt: 2026-07-12
+---
+# With FAQ
+
+Intro paragraph.
+
+## Section one
+
+Some text.
+
+## Frequently Asked Questions (FAQ)
+
+**First question?**
+First **answer** with emphasis.
+
+**Second question?**
+Second answer with a [link](/blog/other-article) inside.
+
+---
+
+*Disclaimer.*`;
+
+// Explicit frontmatter FAQ must win over whatever the body parser would find.
+const PUB_FAQ_FRONTMATTER = `---
+slug: fmfaq
+locale: en
+translationKey: grpfm
+title: FM FAQ
+description: d
+category: VAT
+status: published
+publishedAt: 2026-07-12
+faq:
+  - q: Frontmatter Q?
+    a: Frontmatter A.
+---
+# FM FAQ
+
+## FAQ
+
+**Body Q?**
+Body A.`;
+
 beforeAll(() => {
   base = fs.mkdtempSync(path.join(os.tmpdir(), 'blogtest-'));
   fs.mkdirSync(path.join(base, 'pl'), { recursive: true });
@@ -70,6 +126,8 @@ beforeAll(() => {
   fs.writeFileSync(path.join(base, 'pl', 'older.md'), OLDER_PUB_PL);
   fs.writeFileSync(path.join(base, 'pl', 'secret.md'), DRAFT_PL);
   fs.writeFileSync(path.join(base, 'en', 'sample-en.md'), PUB_EN);
+  fs.writeFileSync(path.join(base, 'en', 'withfaq.md'), PUB_WITH_FAQ);
+  fs.writeFileSync(path.join(base, 'en', 'fmfaq.md'), PUB_FAQ_FRONTMATTER);
 });
 
 afterAll(() => {
@@ -116,6 +174,74 @@ describe('getAnyPostBySlug (preview)', () => {
     expect(getAnyPostBySlug('pl', 'secret', base)?.status).toBe('draft');
     expect(getPostBySlug('pl', 'secret', base)).toBeNull();
   });
+});
+
+describe('parseFaqFromBody', () => {
+  it('extracts question/answer pairs from a body FAQ section', () => {
+    const faq = parseFaqFromBody('## Najczęstsze pytania (FAQ)\n\n**Q1?**\nA1.\n\n**Q2?**\nA2.\n');
+    expect(faq).toEqual([
+      { q: 'Q1?', a: 'A1.' },
+      { q: 'Q2?', a: 'A2.' },
+    ]);
+  });
+
+  it('strips markdown emphasis and links from answers', () => {
+    const faq = parseFaqFromBody('## FAQ\n\n**Q?**\nA with **bold** and a [link](/x) inside.\n');
+    expect(faq[0].a).toBe('A with bold and a link inside.');
+  });
+
+  it('joins a multi-line answer into one string', () => {
+    const faq = parseFaqFromBody('## FAQ\n\n**Q?**\nLine one.\nLine two.\n');
+    expect(faq[0].a).toBe('Line one. Line two.');
+  });
+
+  it('stops at the section terminator (---) and ignores the disclaimer', () => {
+    const faq = parseFaqFromBody('## FAQ\n\n**Q?**\nA.\n\n---\n\n*Disclaimer.*');
+    expect(faq).toEqual([{ q: 'Q?', a: 'A.' }]);
+  });
+
+  it('stops at the next heading after the FAQ', () => {
+    const faq = parseFaqFromBody('## FAQ\n\n**Q?**\nA.\n\n## Next section\n\n**Not?**\nA question.');
+    expect(faq).toEqual([{ q: 'Q?', a: 'A.' }]);
+  });
+
+  it('returns [] when there is no FAQ section', () => {
+    expect(parseFaqFromBody('# Title\n\nNo faq here.\n\n## Spis treści\n\n1. Coś')).toEqual([]);
+  });
+});
+
+describe('FAQ extraction on load', () => {
+  it('populates post.faq from the body FAQ section', () => {
+    const p = getPostBySlug('en', 'withfaq', base);
+    expect(p?.faq).toEqual([
+      { q: 'First question?', a: 'First answer with emphasis.' },
+      { q: 'Second question?', a: 'Second answer with a link inside.' },
+    ]);
+  });
+
+  it('prefers explicit frontmatter faq over the body FAQ', () => {
+    const p = getPostBySlug('en', 'fmfaq', base);
+    expect(p?.faq).toEqual([{ q: 'Frontmatter Q?', a: 'Frontmatter A.' }]);
+  });
+
+  it('leaves faq undefined when the article has no FAQ section', () => {
+    expect(getPostBySlug('pl', 'sample', base)?.faq).toBeUndefined();
+  });
+});
+
+// Reads the real content/blog tree (no baseDir override). Guards the GEO
+// requirement that every published article emits FAQPage structured data:
+// if a new article ships without a `## …FAQ…` section, this fails loudly.
+describe('real published articles all emit FAQ data (GEO guard)', () => {
+  it.each(['pl', 'en', 'ru'] as const)(
+    'every published %s article yields a non-empty FAQ',
+    (locale) => {
+      const posts = getAllPublished(locale);
+      expect(posts.length).toBeGreaterThan(0);
+      const withoutFaq = posts.filter((p) => !p.faq || p.faq.length === 0).map((p) => p.slug);
+      expect(withoutFaq).toEqual([]);
+    },
+  );
 });
 
 describe('getTranslations', () => {

--- a/packages/web/src/lib/blog/content.ts
+++ b/packages/web/src/lib/blog/content.ts
@@ -48,10 +48,72 @@ function toIsoDate(value: unknown): string | null {
   return String(value);
 }
 
+/** Markdown → plain text for a FAQ answer: unwrap links to their text and
+ *  drop bold markers, then collapse whitespace. Keeps the answer clean enough
+ *  for schema.org `acceptedAnswer.text` and AI extraction. */
+function faqPlainText(md: string): string {
+  return md
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // [text](url) -> text
+    .replace(/\*\*(.+?)\*\*/g, '$1') // **bold** -> bold
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Extract FAQ question/answer pairs from an article body.
+ *
+ * Finds the first `## …FAQ…` heading and reads the `**Question?**` /
+ * answer-paragraph pairs beneath it, stopping at the next heading or a thematic
+ * break (`---`, `***`, `___`) — which in our articles precedes the disclaimer.
+ * Returns [] when the article has no FAQ section. Lets us feed FAQPage
+ * structured data straight from the visible prose, with no frontmatter
+ * duplication and no risk of body/schema drift.
+ */
+export function parseFaqFromBody(body: string): BlogFaqItem[] {
+  const lines = body.split(/\r?\n/);
+  const start = lines.findIndex((l) => /^#{2,6}\s.*FAQ/i.test(l));
+  if (start === -1) return [];
+
+  const items: BlogFaqItem[] = [];
+  let q: string | null = null;
+  let answer: string[] = [];
+  const flush = () => {
+    if (q !== null) {
+      const a = faqPlainText(answer.join(' '));
+      if (a) items.push({ q, a });
+    }
+    q = null;
+    answer = [];
+  };
+
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^#{1,6}\s/.test(line) || /^(---|\*\*\*|___)\s*$/.test(line)) break;
+    const question = line.match(/^\*\*(.+?)\*\*\s*$/);
+    if (question) {
+      flush();
+      q = question[1].trim();
+    } else if (line.trim()) {
+      answer.push(line.trim());
+    }
+  }
+  flush();
+  return items;
+}
+
 function parseFile(localeDir: string, locale: BlogLocale, file: string): Post {
   const raw = fs.readFileSync(path.join(localeDir, file), 'utf8');
   const { data, content } = matter(raw);
   const slug = (data.slug as string) ?? file.replace(/\.md$/, '');
+  const body = content.trim();
+  // Explicit frontmatter FAQ wins; otherwise derive it from the body prose so
+  // FAQPage structured data is emitted without duplicating the FAQ by hand.
+  const bodyFaq = parseFaqFromBody(body);
+  const faq = Array.isArray(data.faq)
+    ? (data.faq as BlogFaqItem[])
+    : bodyFaq.length > 0
+      ? bodyFaq
+      : undefined;
   return {
     slug,
     locale,
@@ -66,8 +128,8 @@ function parseFile(localeDir: string, locale: BlogLocale, file: string): Post {
     author: (data.author as string) ?? 'Zespół eKsięgowy AI',
     coverImage: (data.coverImage as string) || undefined,
     ogImage: (data.ogImage as string) || undefined,
-    faq: Array.isArray(data.faq) ? (data.faq as BlogFaqItem[]) : undefined,
-    body: content.trim(),
+    faq,
+    body,
   };
 }
 

--- a/packages/web/src/lib/seo.blog.test.ts
+++ b/packages/web/src/lib/seo.blog.test.ts
@@ -69,6 +69,40 @@ describe('blogPostingJsonLd', () => {
     expect(String(jsonld.mainEntityOfPage)).toContain('/blog/a');
   });
 
+  it('emits a Person author, with url/sameAs/jobTitle when provided', () => {
+    const jsonld = blogPostingJsonLd({
+      title: 'T',
+      description: 'D',
+      slug: 'a',
+      locale: 'pl',
+      publishedAt: '2026-07-10',
+      updatedAt: null,
+      author: 'Mikhail Peraviortkin',
+      authorUrl: 'https://example.com/mikhail',
+      authorJobTitle: 'Founder',
+    }) as { author: Record<string, unknown> };
+    expect(jsonld.author['@type']).toBe('Person');
+    expect(jsonld.author.name).toBe('Mikhail Peraviortkin');
+    expect(jsonld.author.url).toBe('https://example.com/mikhail');
+    expect(jsonld.author.sameAs).toEqual(['https://example.com/mikhail']);
+    expect(jsonld.author.jobTitle).toBe('Founder');
+  });
+
+  it('emits a Person author without url/sameAs when no author URL is given', () => {
+    const jsonld = blogPostingJsonLd({
+      title: 'T',
+      description: 'D',
+      slug: 'a',
+      locale: 'pl',
+      publishedAt: null,
+      updatedAt: null,
+      author: 'Mikhail Peraviortkin',
+    }) as { author: Record<string, unknown> };
+    expect(jsonld.author['@type']).toBe('Person');
+    expect('url' in jsonld.author).toBe(false);
+    expect('sameAs' in jsonld.author).toBe(false);
+  });
+
   it('adds keywords, articleSection and wordCount when provided', () => {
     const jsonld = blogPostingJsonLd({
       title: 'T',

--- a/packages/web/src/lib/seo.blog.test.ts
+++ b/packages/web/src/lib/seo.blog.test.ts
@@ -69,7 +69,7 @@ describe('blogPostingJsonLd', () => {
     expect(String(jsonld.mainEntityOfPage)).toContain('/blog/a');
   });
 
-  it('emits a Person author, with url/sameAs/jobTitle when provided', () => {
+  it('emits a Person author with url, a sameAs list and jobTitle when provided', () => {
     const jsonld = blogPostingJsonLd({
       title: 'T',
       description: 'D',
@@ -78,13 +78,14 @@ describe('blogPostingJsonLd', () => {
       publishedAt: '2026-07-10',
       updatedAt: null,
       author: 'Mikhail Peraviortkin',
-      authorUrl: 'https://example.com/mikhail',
+      authorUrl: 'https://example.com',
+      authorSameAs: ['https://example.com', 'https://linkedin.com/in/x'],
       authorJobTitle: 'Founder',
     }) as { author: Record<string, unknown> };
     expect(jsonld.author['@type']).toBe('Person');
     expect(jsonld.author.name).toBe('Mikhail Peraviortkin');
-    expect(jsonld.author.url).toBe('https://example.com/mikhail');
-    expect(jsonld.author.sameAs).toEqual(['https://example.com/mikhail']);
+    expect(jsonld.author.url).toBe('https://example.com');
+    expect(jsonld.author.sameAs).toEqual(['https://example.com', 'https://linkedin.com/in/x']);
     expect(jsonld.author.jobTitle).toBe('Founder');
   });
 

--- a/packages/web/src/lib/seo.blog.test.ts
+++ b/packages/web/src/lib/seo.blog.test.ts
@@ -68,6 +68,40 @@ describe('blogPostingJsonLd', () => {
     expect(jsonld.datePublished).toBe('2026-07-10');
     expect(String(jsonld.mainEntityOfPage)).toContain('/blog/a');
   });
+
+  it('adds keywords, articleSection and wordCount when provided', () => {
+    const jsonld = blogPostingJsonLd({
+      title: 'T',
+      description: 'D',
+      slug: 'a',
+      locale: 'pl',
+      publishedAt: '2026-07-10',
+      updatedAt: '2026-07-11',
+      author: 'Zespół eKsięgowy AI',
+      keywords: ['vat', 'ksef'],
+      section: 'VAT',
+      wordCount: 1200,
+    }) as Record<string, unknown>;
+    expect(jsonld.keywords).toBe('vat, ksef');
+    expect(jsonld.articleSection).toBe('VAT');
+    expect(jsonld.wordCount).toBe(1200);
+  });
+
+  it('omits keywords/articleSection/wordCount when absent or empty', () => {
+    const jsonld = blogPostingJsonLd({
+      title: 'T',
+      description: 'D',
+      slug: 'a',
+      locale: 'pl',
+      publishedAt: null,
+      updatedAt: null,
+      author: 'Zespół eKsięgowy AI',
+      keywords: [],
+    }) as Record<string, unknown>;
+    expect('keywords' in jsonld).toBe(false);
+    expect('articleSection' in jsonld).toBe(false);
+    expect('wordCount' in jsonld).toBe(false);
+  });
 });
 
 describe('faqPageJsonLd', () => {

--- a/packages/web/src/lib/seo.howto.test.ts
+++ b/packages/web/src/lib/seo.howto.test.ts
@@ -1,0 +1,41 @@
+import { howToJsonLd } from './seo';
+
+const STEPS = [
+  { name: 'Log in', text: 'Open the panel and sign in.' },
+  { name: 'Generate token', text: 'Click generate and copy the value.' },
+];
+
+describe('howToJsonLd', () => {
+  it('builds a HowTo with sequential HowToStep items', () => {
+    const jsonld = howToJsonLd({ name: 'Get KSeF tokens', steps: STEPS }) as {
+      '@context': string;
+      '@type': string;
+      name: string;
+      step: { '@type': string; position: number; name: string; text: string }[];
+    };
+    expect(jsonld['@context']).toBe('https://schema.org');
+    expect(jsonld['@type']).toBe('HowTo');
+    expect(jsonld.name).toBe('Get KSeF tokens');
+    expect(jsonld.step).toHaveLength(2);
+    expect(jsonld.step[0]).toEqual({
+      '@type': 'HowToStep',
+      position: 1,
+      name: 'Log in',
+      text: 'Open the panel and sign in.',
+    });
+    expect(jsonld.step[1].position).toBe(2);
+  });
+
+  it('includes a description when provided', () => {
+    const jsonld = howToJsonLd({ name: 'X', description: 'How to do X.', steps: STEPS }) as Record<
+      string,
+      unknown
+    >;
+    expect(jsonld.description).toBe('How to do X.');
+  });
+
+  it('omits description when not provided', () => {
+    const jsonld = howToJsonLd({ name: 'X', steps: STEPS }) as Record<string, unknown>;
+    expect('description' in jsonld).toBe(false);
+  });
+});

--- a/packages/web/src/lib/seo.llms.test.ts
+++ b/packages/web/src/lib/seo.llms.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @jest-environment node
+ */
+// Node env: route handlers construct a web `Response`, a Node global that the
+// default jsdom environment does not expose. buildLlmsTxt is DOM-agnostic, so
+// running the whole file under node is fine.
+import { buildLlmsTxt, SITE_URL, SITE_NAME } from './seo';
+import { GET } from '@/app/llms.txt/route';
+
+const ARTICLES = [
+  { title: 'Biała lista VAT', slug: 'biala-lista-vat', description: 'Jak sprawdzić kontrahenta.' },
+  { title: 'Składki ZUS 2026', slug: 'skladki-zus-2026', description: 'Ile zapłacisz.' },
+];
+
+describe('buildLlmsTxt', () => {
+  it('starts with the product name as an H1 followed by a summary blockquote', () => {
+    const txt = buildLlmsTxt(ARTICLES);
+    expect(txt.startsWith(`# ${SITE_NAME}`)).toBe(true);
+    expect(txt).toMatch(/\n> .+/);
+  });
+
+  it('links the core product pages with absolute canonical URLs', () => {
+    const txt = buildLlmsTxt(ARTICLES);
+    expect(txt).toContain(`${SITE_URL}/pricing`);
+    expect(txt).toContain(`${SITE_URL}/blog`);
+  });
+
+  it('lists each article as a markdown link (absolute /blog URL) with its description', () => {
+    const txt = buildLlmsTxt(ARTICLES);
+    expect(txt).toContain(
+      `[Biała lista VAT](${SITE_URL}/blog/biala-lista-vat): Jak sprawdzić kontrahenta.`,
+    );
+    expect(txt).toContain(
+      `[Składki ZUS 2026](${SITE_URL}/blog/skladki-zus-2026): Ile zapłacisz.`,
+    );
+  });
+
+  it('does not crash on an empty article list', () => {
+    expect(() => buildLlmsTxt([])).not.toThrow();
+    expect(buildLlmsTxt([]).startsWith(`# ${SITE_NAME}`)).toBe(true);
+  });
+});
+
+describe('GET /llms.txt', () => {
+  it('serves the document as UTF-8 plain text', () => {
+    const res = GET();
+    expect(res.headers.get('Content-Type')).toMatch(/text\/plain/);
+    expect(res.headers.get('Content-Type')).toMatch(/utf-8/i);
+  });
+
+  it('renders the product heading and links real published articles', async () => {
+    const txt = await GET().text();
+    expect(txt.startsWith(`# ${SITE_NAME}`)).toBe(true);
+    expect(txt).toContain(`${SITE_URL}/blog/`);
+  });
+});

--- a/packages/web/src/lib/seo.ts
+++ b/packages/web/src/lib/seo.ts
@@ -305,3 +305,64 @@ export function faqPageJsonLd(faq: { q: string; a: string }[]) {
     })),
   };
 }
+
+// ============================================
+// llms.txt (AI / LLM crawler guidance — llmstxt.org)
+// ============================================
+
+/** One article entry for the llms.txt "Articles" section. */
+export interface LlmsArticle {
+  title: string;
+  slug: string;
+  description: string;
+}
+
+/**
+ * Build the `/llms.txt` document: a concise, link-first Markdown overview that
+ * generative engines (ChatGPT, Perplexity, Gemini, Claude, AI Overviews) read
+ * to understand the site and find its most useful pages. Follows the
+ * llmstxt.org convention — H1 name, `>` summary, then `##` sections of links.
+ *
+ * Links point at the canonical (Polish) URLs; the English/Russian variants live
+ * under `/en` and `/ru`. `articles` is expected newest-first.
+ */
+export function buildLlmsTxt(articles: LlmsArticle[]): string {
+  const link = (label: string, path: string, desc?: string) =>
+    `- [${label}](${absoluteUrl(path)})${desc ? `: ${desc}` : ''}`;
+
+  const lines: string[] = [
+    `# ${SITE_NAME}`,
+    '',
+    '> AI-powered accounting assistant for Polish businesses — integrates with wFirma, ' +
+      'handles KSeF e-invoices, and answers VAT, PIT, CIT and ZUS questions in plain language.',
+    '',
+    `${SITE_NAME} (${SITE_URL}) is a product of MICODE sp. z o.o. It is available in Polish ` +
+      '(default, canonical), English (/en) and Russian (/ru). The links below point to the ' +
+      'canonical Polish URLs.',
+    '',
+    '## Product',
+    '',
+    `- [Home](${SITE_URL}): What ${SITE_NAME} is, its features and who it is for.`,
+    link('Pricing', '/pricing', 'Plans, including a free tier when you bring your own OpenAI key.'),
+    link('Blog', '/blog', 'Explainers and how-tos on Polish accounting, taxes and KSeF.'),
+    '',
+    '## Guides',
+    '',
+    link('KSeF setup', '/guide/ksef', "Connect and send e-invoices through Poland's National e-Invoice System (KSeF)."),
+    link('wFirma integration', '/guide/wfirma', 'Link your wFirma account and API credentials.'),
+    link('Telegram bot', '/guide/telegram', 'Book expenses from receipt photos via Telegram OCR.'),
+    '',
+    '## Articles',
+    '',
+    ...articles.map((a) => link(a.title, `/blog/${a.slug}`, a.description)),
+    '',
+    '## Company',
+    '',
+    link('Terms of Service', '/terms'),
+    link('Privacy Policy', '/privacy-policy'),
+    link('RODO / GDPR', '/rodo'),
+    '',
+  ];
+
+  return lines.join('\n');
+}

--- a/packages/web/src/lib/seo.ts
+++ b/packages/web/src/lib/seo.ts
@@ -277,8 +277,15 @@ export function breadcrumbJsonLd(items: Array<{ name: string; path: string }>) {
  * strongest authorship signal for AI answer engines and search — and `jobTitle`
  * for the person's role.
  */
-export const ARTICLE_AUTHOR: { name: string; url?: string; jobTitle?: string } = {
+export const ARTICLE_AUTHOR: {
+  name: string;
+  url?: string;
+  sameAs?: string[];
+  jobTitle?: string;
+} = {
   name: 'Mikhail Peraviortkin',
+  url: 'http://mi-code.pl',
+  sameAs: ['http://mi-code.pl', 'https://www.linkedin.com/in/mikhailperaviortkin/'],
 };
 
 /**
@@ -310,8 +317,10 @@ export function blogPostingJsonLd(input: {
   publishedAt: string | null;
   updatedAt: string | null;
   author: string;
-  /** Author profile URL → Person `url` + `sameAs` (strongest E-E-A-T signal). */
+  /** Author homepage → Person `url`. */
   authorUrl?: string;
+  /** Author's authoritative profiles → Person `sameAs` (strongest E-E-A-T signal). */
+  authorSameAs?: string[];
   /** Author role → Person `jobTitle`. */
   authorJobTitle?: string;
   coverImage?: string | null;
@@ -335,7 +344,10 @@ export function blogPostingJsonLd(input: {
     author: {
       '@type': 'Person',
       name: input.author,
-      ...(input.authorUrl ? { url: input.authorUrl, sameAs: [input.authorUrl] } : {}),
+      ...(input.authorUrl ? { url: input.authorUrl } : {}),
+      ...(input.authorSameAs && input.authorSameAs.length > 0
+        ? { sameAs: input.authorSameAs }
+        : {}),
       ...(input.authorJobTitle ? { jobTitle: input.authorJobTitle } : {}),
     },
     publisher: { '@type': 'Organization', name: 'MICODE sp. z o.o.' },

--- a/packages/web/src/lib/seo.ts
+++ b/packages/web/src/lib/seo.ts
@@ -300,6 +300,12 @@ export function blogPostingJsonLd(input: {
   updatedAt: string | null;
   author: string;
   coverImage?: string | null;
+  /** Article tags → schema `keywords` (topical signal for AI/search engines). */
+  keywords?: string[];
+  /** Article category → schema `articleSection`. */
+  section?: string;
+  /** Approximate body word count → schema `wordCount` (quality/depth signal). */
+  wordCount?: number;
 }) {
   return {
     '@context': 'https://schema.org',
@@ -313,6 +319,11 @@ export function blogPostingJsonLd(input: {
     publisher: { '@type': 'Organization', name: 'MICODE sp. z o.o.' },
     mainEntityOfPage: absoluteUrl(localizedPath(`/blog/${input.slug}`, input.locale)),
     image: input.coverImage || undefined,
+    ...(input.keywords && input.keywords.length > 0
+      ? { keywords: input.keywords.join(', ') }
+      : {}),
+    ...(input.section ? { articleSection: input.section } : {}),
+    ...(input.wordCount && input.wordCount > 0 ? { wordCount: input.wordCount } : {}),
   };
 }
 

--- a/packages/web/src/lib/seo.ts
+++ b/packages/web/src/lib/seo.ts
@@ -271,6 +271,17 @@ export function breadcrumbJsonLd(items: Array<{ name: string; path: string }>) {
 // ============================================
 
 /**
+ * The named person behind the articles (E-E-A-T: a real human author, not just
+ * the organization). Used for both the visible byline and the BlogPosting
+ * `author`. Add `url` (LinkedIn / personal / author page) to emit `sameAs` — the
+ * strongest authorship signal for AI answer engines and search — and `jobTitle`
+ * for the person's role.
+ */
+export const ARTICLE_AUTHOR: { name: string; url?: string; jobTitle?: string } = {
+  name: 'Mikhail Peraviortkin',
+};
+
+/**
  * hreflang alternates for a blog article, built ONLY from the locales that
  * actually have a published translation. `x-default` points at the Polish
  * variant if present, otherwise the active locale.
@@ -299,6 +310,10 @@ export function blogPostingJsonLd(input: {
   publishedAt: string | null;
   updatedAt: string | null;
   author: string;
+  /** Author profile URL → Person `url` + `sameAs` (strongest E-E-A-T signal). */
+  authorUrl?: string;
+  /** Author role → Person `jobTitle`. */
+  authorJobTitle?: string;
   coverImage?: string | null;
   /** Article tags → schema `keywords` (topical signal for AI/search engines). */
   keywords?: string[];
@@ -315,7 +330,14 @@ export function blogPostingJsonLd(input: {
     inLanguage: LOCALE_BCP47[input.locale],
     datePublished: input.publishedAt ?? undefined,
     dateModified: input.updatedAt ?? input.publishedAt ?? undefined,
-    author: { '@type': 'Organization', name: input.author },
+    // A named Person author (not the org) is a stronger authorship/E-E-A-T
+    // signal for AI answer engines and search; the org remains the publisher.
+    author: {
+      '@type': 'Person',
+      name: input.author,
+      ...(input.authorUrl ? { url: input.authorUrl, sameAs: [input.authorUrl] } : {}),
+      ...(input.authorJobTitle ? { jobTitle: input.authorJobTitle } : {}),
+    },
     publisher: { '@type': 'Organization', name: 'MICODE sp. z o.o.' },
     mainEntityOfPage: absoluteUrl(localizedPath(`/blog/${input.slug}`, input.locale)),
     image: input.coverImage || undefined,

--- a/packages/web/src/lib/seo.ts
+++ b/packages/web/src/lib/seo.ts
@@ -229,6 +229,29 @@ export const SOFTWARE_APPLICATION_JSONLD = {
   publisher: { '@type': 'Organization', name: 'MICODE sp. z o.o.' },
 };
 
+/**
+ * HowTo structured data for a step-by-step guide. Generative engines and rich
+ * results surface procedural content from this — each step becomes a HowToStep.
+ */
+export function howToJsonLd(input: {
+  name: string;
+  description?: string;
+  steps: { name: string; text: string }[];
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'HowTo',
+    name: input.name,
+    ...(input.description ? { description: input.description } : {}),
+    step: input.steps.map((s, index) => ({
+      '@type': 'HowToStep',
+      position: index + 1,
+      name: s.name,
+      text: s.text,
+    })),
+  };
+}
+
 /** Build a BreadcrumbList for a guide page. */
 export function breadcrumbJsonLd(items: Array<{ name: string; path: string }>) {
   return {


### PR DESCRIPTION
## What & why

A **GEO (Generative Engine Optimization)** pass so AI answer engines — ChatGPT / OAI-Search, Perplexity, Gemini, Google AI Overviews, Claude — can extract, cite and recommend our content. Complements the existing SEO work; branched clean off `development` (it already has the blog, byline, translations, cross-promo — this PR is **only** the GEO delta).

## Changes

| Area | What |
|---|---|
| **FAQPage JSON-LD** | `parseFaqFromBody()` derives Q&A from the in-body `## …FAQ…` prose of every article, so `FAQPage` structured data is now emitted on all 36 articles (12 × pl/en/ru). Single source of truth — no frontmatter duplication; explicit `faq:` frontmatter still overrides. |
| **/llms.txt** | New route handler + `buildLlmsTxt()` serving a link-first Markdown overview (llmstxt.org convention): product, guides, and all published articles with descriptions. |
| **HowTo JSON-LD** | `howToJsonLd()` + a `howToSteps` prop on `GuidePageLayout`, wired into the 3 step-by-step guides (KSeF get-tokens, wFirma get-api-credentials, Telegram setup). |
| **robots AI-crawler allowlist** | Explicit allow rules for GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, Claude-User, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, CCBot. |
| **BlogPosting enrichment** | `keywords` (tags), `articleSection` (category), `wordCount`. |
| **Named Person author (E-E-A-T)** | Central `ARTICLE_AUTHOR` identity (Mikhail Peraviortkin) used for byline + `author`, now a schema.org `Person` with `url` + `sameAs` (mi-code.pl, LinkedIn). Org stays the publisher. |

## Testing

All changes are test-driven. Full web Jest suite green on the `development` base: **87 passed / 15 suites**, typecheck clean (touched files). Includes a real-content guard asserting every published article in all locales yields a non-empty FAQ.

## Notes

- `main` doesn't exist on origin; `development` is the integration branch (matches prior blog PRs #154/#155).
- The GEO commits also live on `feature/blog`; this branch isolates them onto `development` so the diff is reviewable (a direct `feature/blog` PR would re-show the already-merged blog as a ~7.6k-line diff due to squash-merge history).

🤖 Generated with [Claude Code](https://claude.com/claude-code)