### PR TITLE
ci: raise deploy SSH command_timeout 10m -> 20m

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -153,7 +153,11 @@ jobs:
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
           script_stop: true
-          command_timeout: 10m
+          # The VPS builds the api + web Docker images on-server (scripts/deploy.sh);
+          # the web `next build` (compile + typecheck) alone can approach 10m on this
+          # budget box, so the combined build was overrunning the default and getting
+          # killed mid-typecheck. 20m gives on-server builds headroom.
+          command_timeout: 20m
           script: |
             cd /opt/accounting-ai-agent
             bash scripts/deploy.sh


### PR DESCRIPTION
## Why

The **Deploy to Hetzner VPS** job in `ci-cd.yml` failed on the last `development` push ([run 29321678490](https://github.com/micode-ai/accounting-ai-agent/actions/runs/29321678490)) with `Run Command Timeout` → exit 1 — but **not because of a code problem**: Lint, Test API, Build and Test Web all passed, and the app built (`✓ Compiled successfully in 2.7min`).

The deploy SSHes into the VPS and runs `scripts/deploy.sh`, which builds the **api + web Docker images on the server**. On this budget box the web `next build` (compile + typecheck) plus the api build overran `appleboy/ssh-action`'s `command_timeout: 10m`, so the command was killed mid-typecheck (job ran exactly 10m5s).

## Change

`command_timeout: 10m → 20m` — headroom for on-server builds.

Merging this to `development` also re-triggers the deploy pipeline (with the new timeout + a warmer Docker cache), so it doubles as the re-run.

## Follow-up (not here)

Build images on CI runners and have the VPS `pull` from a registry to remove the slow on-server build entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)