### PR TITLE
feat(seo/geo): clickable author byline (homepage + LinkedIn) for E-E-A-T

### DIFF
--- a/packages/web/src/app/blog/[slug]/page.tsx
+++ b/packages/web/src/app/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import {
   SITE_NAME,
   LOCALE_BCP47,
   ARTICLE_AUTHOR,
+  findLinkedIn,
   blogAlternatesFor,
   blogPostingJsonLd,
   faqPageJsonLd,
@@ -100,6 +101,7 @@ export default async function BlogArticlePage({ params }: Params) {
         year: 'numeric',
       })
     : null;
+  const authorLinkedIn = findLinkedIn(ARTICLE_AUTHOR.sameAs);
 
   return (
     <main className="max-w-3xl mx-auto px-4 py-10">
@@ -118,11 +120,35 @@ export default async function BlogArticlePage({ params }: Params) {
           {post.title}
         </h1>
         <p className="mt-3 text-sm text-gray-500 dark:text-gray-400">
-          {ARTICLE_AUTHOR.name}
+          {ARTICLE_AUTHOR.url ? (
+            <a
+              href={ARTICLE_AUTHOR.url}
+              rel="author noopener noreferrer"
+              target="_blank"
+              className="font-medium hover:text-gray-700 dark:hover:text-gray-200 hover:underline"
+            >
+              {ARTICLE_AUTHOR.name}
+            </a>
+          ) : (
+            ARTICLE_AUTHOR.name
+          )}
           {dateLabel && (
             <>
               {' · '}
               <time dateTime={post.publishedAt ?? undefined}>{dateLabel}</time>
+            </>
+          )}
+          {authorLinkedIn && (
+            <>
+              {' · '}
+              <a
+                href={authorLinkedIn}
+                rel="noopener noreferrer"
+                target="_blank"
+                className="hover:text-gray-700 dark:hover:text-gray-200 hover:underline"
+              >
+                LinkedIn
+              </a>
             </>
           )}
         </p>

--- a/packages/web/src/lib/seo.blog.test.ts
+++ b/packages/web/src/lib/seo.blog.test.ts
@@ -2,10 +2,29 @@ import {
   blogAlternatesFor,
   blogPostingJsonLd,
   faqPageJsonLd,
+  findLinkedIn,
   splitLocale,
   localizedPath,
   type Locale,
 } from './seo';
+
+describe('findLinkedIn', () => {
+  it('returns the LinkedIn URL from a sameAs list', () => {
+    expect(findLinkedIn(['http://mi-code.pl', 'https://www.linkedin.com/in/x/'])).toBe(
+      'https://www.linkedin.com/in/x/',
+    );
+  });
+
+  it('matches linkedin.com case-insensitively', () => {
+    expect(findLinkedIn(['https://LinkedIn.com/in/y'])).toBe('https://LinkedIn.com/in/y');
+  });
+
+  it('returns undefined when there is no LinkedIn profile, or the list is empty/undefined', () => {
+    expect(findLinkedIn(['http://mi-code.pl'])).toBeUndefined();
+    expect(findLinkedIn([])).toBeUndefined();
+    expect(findLinkedIn(undefined)).toBeUndefined();
+  });
+});
 
 describe('locale switch target (regression: prefixes must not stack)', () => {
   // Mirrors what useLocaleSwitcher computes: strip any existing locale prefix,

--- a/packages/web/src/lib/seo.ts
+++ b/packages/web/src/lib/seo.ts
@@ -288,6 +288,12 @@ export const ARTICLE_AUTHOR: {
   sameAs: ['http://mi-code.pl', 'https://www.linkedin.com/in/mikhailperaviortkin/'],
 };
 
+/** The LinkedIn profile URL within a `sameAs` list, if any — for a visible
+ *  byline link that corroborates the JSON-LD `sameAs` (stronger E-E-A-T). */
+export function findLinkedIn(sameAs: string[] | undefined): string | undefined {
+  return sameAs?.find((u) => /linkedin\.com/i.test(u));
+}
+
 /**
  * hreflang alternates for a blog article, built ONLY from the locales that
  * actually have a published translation. `x-default` points at the Polish


### PR DESCRIPTION
## Why

Follow-up to #156. The author's profile links (mi-code.pl + LinkedIn) were present only in the article **JSON-LD** (`Person.url` + `sameAs`) — invisible on the page. Search and AI answer engines cross-check visible content against structured data, so a **visible, clickable author link that matches `sameAs`** is a stronger, corroborated authorship/E-E-A-T signal (and is useful to readers).

## Change

The article byline now renders:
- Author name → link to the homepage with `rel="author"` (`http://mi-code.pl`)
- A `LinkedIn` link alongside the date

`findLinkedIn()` extracts the LinkedIn URL from `ARTICLE_AUTHOR.sameAs`. Degrades gracefully (plain text if no url; no LinkedIn link if none present).

## Testing

TDD `findLinkedIn` unit tests; **rendered output verified locally** (name → mi-code.pl `rel="author"`, LinkedIn link present, JSON-LD `Person` intact). Full web Jest suite green (**90 tests**), typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)