### PR TITLE
fix(ci): Chromatic TurboSnap stats + api Dockerfile apk retry

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,6 +13,9 @@ on:
       - 'packages/web/src/**'
       - 'packages/web/.storybook/**'
       - 'packages/web/package.json'
+  # Allow manual runs (e.g. to re-baseline snapshots or verify a config change
+  # that doesn't touch the trigger paths above).
+  workflow_dispatch:
 
 env:
   NODE_VERSION: '18'
@@ -40,7 +43,10 @@ jobs:
 
       - name: Build Storybook
         working-directory: packages/web
-        run: npm run build-storybook
+        # --stats-json emits preview-stats.json, which Chromatic TurboSnap
+        # (onlyChanged: true) needs to trace changed files. Without it the
+        # action errors: "TurboSnap disabled due to missing stats file".
+        run: npm run build-storybook -- --stats-json
 
       - name: Run Chromatic
         uses: chromaui/action@latest

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -24,7 +24,15 @@ RUN npm run build
 # Production stage
 FROM node:20-alpine
 
-RUN apk add --no-cache openssl
+# openssl is required by Prisma at runtime. Retry to ride out transient Alpine
+# mirror/DNS hiccups (e.g. "fetching APKINDEX...: DNS: transient error") that
+# would otherwise fail the whole on-VPS deploy build.
+RUN for i in 1 2 3 4 5; do \
+      apk add --no-cache openssl && break; \
+      echo "apk add openssl failed (attempt $i/5); retrying in 5s..."; \
+      sleep 5; \
+    done; \
+    apk info -e openssl > /dev/null
 
 WORKDIR /app
 


### PR DESCRIPTION
Two independent CI/deploy reliability fixes flagged during the GEO deploy work.

## 1. Chromatic Visual Testing — failing on every push

The `Run Chromatic` step failed on **every** recent push (unrelated PRs: #156, AIA-88, AIA-153). Root cause is **not** the token — the action errored:

```
✖ TurboSnap disabled due to missing stats file
Did not find preview-stats.json in your built Storybook.
Make sure you pass --stats-json when building your Storybook.
✖ Failed to prepare your built Storybook
```

`onlyChanged: true` (TurboSnap) needs `preview-stats.json`, but the Build Storybook step ran `storybook build` **without** `--stats-json`.

**Fix:** add `--stats-json` to the Build Storybook step. Verified locally — it now emits `storybook-static/preview-stats.json` (985 KB). Also added `workflow_dispatch` so the visual suite can be triggered manually (its path filters otherwise skip config-only changes like this one).

## 2. api Dockerfile — deploy killed by a transient apk/DNS flake

The last byline deploy (run 29329846150) failed in 13s:

```
#18 [api stage-1 2/8] RUN apk add --no-cache openssl
  WARNING: fetching .../APKINDEX.tar.gz: DNS: transient error (try again later)
  ERROR: openssl (no such package)
```

`apk add openssl` (openssl is required by Prisma) had no retry, so one bad DNS moment on the budget VPS failed the whole on-server build.

**Fix:** 5× retry loop with a final `apk info -e openssl` guard (still fails loudly if openssl genuinely can't install). Shell syntax checked with `sh -n`.

## Verification
- Chromatic: local `build-storybook -- --stats-json` produces `preview-stats.json` ✔. After merge I'll `workflow_dispatch` the Chromatic run to confirm green end-to-end.
- Dockerfile: merge triggers the CI/CD deploy, which rebuilds the api image and exercises the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)